### PR TITLE
Add tagMap/typeMap aliases to encoder and decoder modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,11 @@
 
+Revision 0.5.0.rc2, released ??-??-2022
+---------------------------------------
+
+- Re-add ``tagMap`` and ``typeMap`` module level attributes to all
+  encoder and decoder modules. They are aliases for ``TAG_MAP`` and
+  ``TYPE_MAP``, [issue #9](https://github.com/pyasn1/pyasn1/issues/9).
+
 Revision 0.5.0.rc1, released 08-08-2022
 ---------------------------------------
 

--- a/pyasn1/__init__.py
+++ b/pyasn1/__init__.py
@@ -1,2 +1,2 @@
 # https://www.python.org/dev/peps/pep-0396/
-__version__ = '0.5.0.rc1'
+__version__ = '0.5.0.dev2'

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -1450,6 +1450,10 @@ TYPE_MAP = {
     univ.Any.typeId: AnyPayloadDecoder()
 }
 
+# deprecated aliases, https://github.com/pyasn1/pyasn1/issues/9
+tagMap = TAG_MAP
+typeMap = TYPE_MAP
+
 # Put in non-ambiguous types for faster codec lookup
 for typeDecoder in TAG_MAP.values():
     if typeDecoder.protoComponent is not None:

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -773,6 +773,10 @@ TYPE_MAP = {
     useful.UTCTime.typeId: OctetStringEncoder()
 }
 
+# deprecated aliases, https://github.com/pyasn1/pyasn1/issues/9
+tagMap = TAG_MAP
+typeMap = TYPE_MAP
+
 
 class SingleItemEncoder(object):
     fixedDefLengthMode = None

--- a/pyasn1/codec/cer/decoder.py
+++ b/pyasn1/codec/cer/decoder.py
@@ -62,6 +62,10 @@ TAG_MAP.update(
 
 TYPE_MAP = decoder.TYPE_MAP.copy()
 
+# deprecated aliases, https://github.com/pyasn1/pyasn1/issues/9
+tagMap = TAG_MAP
+typeMap = TYPE_MAP
+
 # Put in non-ambiguous types for faster codec lookup
 for typeDecoder in TAG_MAP.values():
     if typeDecoder.protoComponent is not None:

--- a/pyasn1/codec/cer/encoder.py
+++ b/pyasn1/codec/cer/encoder.py
@@ -260,6 +260,10 @@ TYPE_MAP.update({
     univ.SequenceOf.typeId: SequenceOfEncoder()
 })
 
+# deprecated aliases, https://github.com/pyasn1/pyasn1/issues/9
+tagMap = TAG_MAP
+typeMap = TYPE_MAP
+
 
 class SingleItemEncoder(encoder.SingleItemEncoder):
     fixedDefLengthMode = False

--- a/pyasn1/codec/der/decoder.py
+++ b/pyasn1/codec/der/decoder.py
@@ -30,6 +30,10 @@ TAG_MAP.update(
 
 TYPE_MAP = decoder.TYPE_MAP.copy()
 
+# deprecated aliases, https://github.com/pyasn1/pyasn1/issues/9
+tagMap = TAG_MAP
+typeMap = TYPE_MAP
+
 # Put in non-ambiguous types for faster codec lookup
 for typeDecoder in TAG_MAP.values():
     if typeDecoder.protoComponent is not None:

--- a/pyasn1/codec/der/encoder.py
+++ b/pyasn1/codec/der/encoder.py
@@ -57,6 +57,10 @@ TYPE_MAP.update({
     univ.Set.typeId: SetEncoder()
 })
 
+# deprecated aliases, https://github.com/pyasn1/pyasn1/issues/9
+tagMap = TAG_MAP
+typeMap = TYPE_MAP
+
 
 class SingleItemEncoder(encoder.SingleItemEncoder):
     fixedDefLengthMode = True

--- a/pyasn1/codec/native/decoder.py
+++ b/pyasn1/codec/native/decoder.py
@@ -129,6 +129,10 @@ TYPE_MAP = {
     useful.UTCTime.typeId: AbstractScalarPayloadDecoder()
 }
 
+# deprecated aliases, https://github.com/pyasn1/pyasn1/issues/9
+tagMap = TAG_MAP
+typeMap = TYPE_MAP
+
 
 class SingleItemDecoder(object):
 

--- a/pyasn1/codec/native/encoder.py
+++ b/pyasn1/codec/native/encoder.py
@@ -170,6 +170,10 @@ TYPE_MAP = {
     useful.UTCTime.typeId: OctetStringEncoder()
 }
 
+# deprecated aliases, https://github.com/pyasn1/pyasn1/issues/9
+tagMap = TAG_MAP
+typeMap = TYPE_MAP
+
 
 class SingleItemEncoder(object):
 


### PR DESCRIPTION
The module level attributes were renamed in
93e11a2dfded950827ba3393b5a4562270a766da. ldap3 uses the attributes.

Closes: #9