### PR TITLE
`RealEncoder.supportIndefLenMode` as a boolean

### DIFF
--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -354,7 +354,7 @@ class ObjectIdentifierEncoder(AbstractItemEncoder):
 
 
 class RealEncoder(AbstractItemEncoder):
-    supportIndefLenMode = 0
+    supportIndefLenMode = False
     binEncBase = 2  # set to None to choose encoding base automatically
 
     @staticmethod


### PR DESCRIPTION
Every other `supportIndefLenMode` are booleans, this seems like a mistake/leftover from python 2