### PR TITLE
Fix CI for py39 environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 3.5.0
+minversion = 3.18.0
 envlist =
     py27, py36, py37, py38, py39, py310, py311, pypy27, pypy37, pypy38, pypy39
     cover, docs, bandit, build
@@ -26,7 +26,7 @@ commands =
     bandit -r pyasn1 -c .bandit.yml
 
 [testenv:docs]
-whitelist_externals = make
+allowlist_externals = make
 deps =
     sphinx
 commands = make -C docs html SPHINXOPTS="-W --keep-going"


### PR DESCRIPTION
`whitelist_externals` was deprecated as of 3.18 and has been replaced by `allowlist_externals`. Use the new variable name to unbreak CI with py39.

Bump the minimum tox version to support the change (3.18 was where `allowlist_externals` was introduced).

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>