### PR TITLE
Link fix (Layman's Guide)

### DIFF
--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -155,7 +155,7 @@ Here you can get the official standards which is hard to read:
 
 On the other end of the readability spectrum, here is a quick and sweet write up:
 
-* `A Layman's Guide to a Subset of ASN.1, BER, and DER <ftp://ftp.rsasecurity.com/pub/pkcs/ascii/layman.asc>`_ by Burton S. Kaliski
+* `A Layman's Guide to a Subset of ASN.1, BER, and DER <https://www.researchgate.net/publication/2820226_A_Layman's_Guide_to_a_Subset_of_ASN1_BER_and_DER>`_ by Burton S. Kaliski
 
 If you are working with ASN.1, we'd highly recommend reading a proper
 book on the subject.


### PR DESCRIPTION
- Domain ftp.rsasecurity.com no longer resolves (NXDOMAIN).
- ftp protocol no longer supported natively in browsers.

The link provided links to a formatted PDF version of the paper, at a stable domain (researchgate), using https.