### PR TITLE
Remove support for EOL Python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,23 +28,16 @@ env:
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }}"
-    # 20.04 because https://github.com/actions/python-versions
-    # does not have 2.7 and 3.6 binaries for 22.04.
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12-dev"
-          - "pypy-2.7"
-          - "pypy-3.7"
           - "pypy-3.8"
           - "pypy-3.9"
           - "pypy-3.10"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
-Revision 0.5.2, released xx-xx-2024
+Revision 0.6.0, released xx-03-2024
 ---------------------------------------
 
+- Removed support for EOL Python 2.7, 3.6, 3.7
 - Added support for previously missing `RELATIVE-OID` construct
 
 Revision 0.5.1, released 20-11-2023

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features
 * Standards compliant BER/CER/DER codecs
 * Can operate on streams of serialized data
 * Dumps/loads ASN.1 structures from Python types
-* 100% Python, works with Python 2.7 and 3.6+
+* 100% Python, works with Python 3.8+
 * MT-safe
 * Contributed ASN.1 compiler [Asn1ate](https://github.com/kimgr/asn1ate)
 

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -3,7 +3,7 @@ Download & Install
 ==================
 
 The *pyasn1* library is a pure-Python package with no external
-dependencies. It works with Python 2.7 and 3.4+.
+dependencies. It works with Python 3.8+.
 
 The best way to obtain PyASN1 is by running `pip`:
 

--- a/docs/source/pyasn1/contents.rst
+++ b/docs/source/pyasn1/contents.rst
@@ -20,7 +20,7 @@ implementation of pyasn1 classes from ASN.1 specification.
 
 Both `pyasn1 <https://github.com/pyasn1/pyasn1>`_ and
 `pyasn1-modules <https://github.com/pyasn1/pyasn1-modules>`_ libraries
-can be used out-of-the-box with Python versions 2.7 and 3.4+.
+can be used out-of-the-box with Python versions 3.8+.
 No external dependencies required.
 
 .. _pyasn1-types:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,7 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -44,7 +40,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
+python_requires = >=3.8
 zip_safe = True
 setup_requires = setuptools
 packages =

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -1835,7 +1835,7 @@ class BytesIOTestCase(BaseTestCase):
 
 class UnicodeTestCase(BaseTestCase):
     def testFail(self):
-        # This ensures that unicode objects in Python 2 & str objects in Python 3.7 cannot be parsed.
+        # This ensures that str objects in Python 3.7 cannot be parsed.
         source = ints2octs((2, 1, 12, 35, 128, 3, 2, 0, 169, 3, 2, 1, 138, 0, 0)).decode("latin-1")
         try:
             next(decoder.StreamingDecoder(source))
@@ -1963,8 +1963,7 @@ class CompressedFilesTestCase(BaseTestCase):
             os.remove(path)
 
     def testZipfile(self):
-        # File from ZIP archive is a good example of non-seekable stream in Python 2.7
-        #   In Python 3.7, it is a seekable stream.
+        # It is a seekable stream.
         _, path = tempfile.mkstemp(suffix=".zip")
         try:
             with zipfile.ZipFile(path, "w") as myzip:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.18.0
 envlist =
-    py27, py36, py37, py38, py39, py310, py311, py312, pypy27, pypy37, pypy38, pypy39
+    py38, py39, py310, py311, py312, pypy38, pypy39
     cover, docs, bandit, build
 isolated_build = true
 skip_missing_interpreters = true
@@ -43,16 +43,11 @@ commands =
 
 [gh-actions]
 python =
-    2.7: py27
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39, docs
     3.10: py310, cover, build, bandit
     3.11: py311
     3.12: py312
-    pypy-2.7: pypy27
-    pypy-3.7: pypy37
     pypy-3.8: pypy38
     pypy-3.9: pypy39
     pypy-3.10: pypy310


### PR DESCRIPTION
Remove Python 2.7, 3.6, and 3.7 as EOL.