### PR TITLE
setup.cfg: remove bdist_wheel.universal=1 flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,3 @@ packages =
     pyasn1.codec.cer
     pyasn1.codec.der
     pyasn1.codec.native
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
This package isn't compatible with Python 2, so having py2 in the wheel name is incorrect.

### Before

```
$ python -m build .
Successfully built pyasn1-0.6.0.tar.gz and pyasn1-0.6.0-py2.py3-none-any.whl
```

### After

```
$ python -m build .
Successfully built pyasn1-0.6.0.tar.gz and pyasn1-0.6.0-py3-none-any.whl
```
