### PR TITLE
Simplified error handling using Python 3 syntax

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -623,10 +623,10 @@ class ConstructedPayloadDecoderBase(AbstractConstructedPayloadDecoder):
     protoSequenceComponent = None
 
     def _getComponentTagMap(self, asn1Object, idx):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _getComponentPositionByType(self, asn1Object, tagSet, idx):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _decodeComponentsSchemaless(
             self, substrate, tagSet=None, decodeFun=None,
@@ -2091,9 +2091,8 @@ class Decoder(object):
                 """
                 try:
                     substrate_gen = origSubstrateFun(asn1Object, substrate, length, options)
-                except TypeError:
-                    _type, _value, traceback = sys.exc_info()
-                    if traceback.tb_next:
+                except TypeError as _value:
+                    if _value.__traceback__.tb_next:
                         # Traceback depth > 1 means TypeError from inside user provided function
                         raise
                     # invariant maintained at Decoder.__call__ entry

--- a/pyasn1/codec/ber/encoder.py
+++ b/pyasn1/codec/ber/encoder.py
@@ -101,10 +101,9 @@ class AbstractItemEncoder(object):
                         value, asn1Spec, encodeFun, **options
                     )
 
-                except error.PyAsn1Error:
-                    exc = sys.exc_info()
+                except error.PyAsn1Error as exc:
                     raise error.PyAsn1Error(
-                        'Error encoding %r: %s' % (value, exc[1]))
+                        'Error encoding %r: %s' % (value, exc))
 
                 if LOG:
                     LOG('encoded %svalue %s into %s' % (

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -140,7 +140,7 @@ class Asn1Type(Asn1Item):
         return True
 
     def prettyPrint(self, scope=0):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     # backward compatibility
 
@@ -267,9 +267,8 @@ class SimpleAsn1Type(Asn1Type):
             try:
                 self.subtypeSpec(value)
 
-            except error.PyAsn1Error:
-                exType, exValue, exTb = sys.exc_info()
-                raise exType('%s at %s' % (exValue, self.__class__.__name__))
+            except error.PyAsn1Error as exValue:
+                raise type(exValue)('%s at %s' % (exValue, self.__class__.__name__))
 
         self._value = value
 

--- a/pyasn1/type/char.py
+++ b/pyasn1/type/char.py
@@ -59,8 +59,7 @@ class AbstractCharacterString(univ.OctetString):
     def __bytes__(self):
         try:
             return self._value.encode(self.encoding)
-        except UnicodeEncodeError:
-            exc = sys.exc_info()[1]
+        except UnicodeEncodeError as exc:
             raise error.PyAsn1UnicodeEncodeError(
                 "Can't encode string '%s' with codec "
                 "%s" % (self._value, self.encoding), exc
@@ -79,8 +78,7 @@ class AbstractCharacterString(univ.OctetString):
             else:
                 return str(value)
 
-        except (UnicodeDecodeError, LookupError):
-            exc = sys.exc_info()[1]
+        except (UnicodeDecodeError, LookupError) as exc:
             raise error.PyAsn1UnicodeDecodeError(
                 "Can't decode string '%s' with codec "
                 "%s" % (value, self.encoding), exc

--- a/pyasn1/type/constraint.py
+++ b/pyasn1/type/constraint.py
@@ -31,9 +31,9 @@ class AbstractConstraint(object):
         try:
             self._testValue(value, idx)
 
-        except error.ValueConstraintError:
+        except error.ValueConstraintError as exc:
             raise error.ValueConstraintError(
-                '%s failed at: %r' % (self, sys.exc_info()[1])
+                '%s failed at: %r' % (self, exc)
             )
 
     def __repr__(self):

--- a/pyasn1/type/tag.py
+++ b/pyasn1/type/tag.py
@@ -98,7 +98,7 @@ class Tag(object):
         elif idx == 2:
             return self.__tagId
         else:
-            raise IndexError()
+            raise IndexError
 
     def __iter__(self):
         yield self.__tagClass

--- a/pyasn1/type/tagmap.py
+++ b/pyasn1/type/tagmap.py
@@ -46,7 +46,7 @@ class TagMap(object):
             return self.__presentTypes[tagSet]
         except KeyError:
             if self.__defaultType is None:
-                raise KeyError()
+                raise
             elif tagSet in self.__skipTypes:
                 raise error.PyAsn1Error('Key in negative map')
             else:

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -1746,9 +1746,7 @@ class ErrorOnDecodingTestCase(BaseTestCase):
             asn1Object = next(decode(stream))
 
         except error.PyAsn1Error:
-            exc = sys.exc_info()[1]
-            assert isinstance(exc, error.PyAsn1Error), (
-                'Unexpected exception raised %r' % (exc,))
+            pass
 
         else:
             assert False, 'Unexpected decoder result %r' % (asn1Object,)


### PR DESCRIPTION
https://github.com/pyasn1/pyasn1/commit/81ce8d0d5f1c6ae4662cdc1fe141b7ea0cd28e00 removed support for Python 2, so error handling can be migrated to Python 3 syntax.

~~I've left in `sys.exec_info` that would be removed by https://github.com/pyasn1/pyasn1/pull/62 (modifying those would be invalid Python 2 syntax anyway)~~ (that PR has now been merged)