### PR TITLE
Accept decoding bytearray and memoryview (#29)

### DIFF
--- a/pyasn1/codec/streaming.py
+++ b/pyasn1/codec/streaming.py
@@ -83,7 +83,8 @@ def asSeekableStream(substrate):
 
     Parameters
     ----------
-    substrate: :py:class:`bytes` or :py:class:`io.IOBase` or :py:class:`univ.OctetString`
+    substrate: :py:class:`bytes` or :py:class:`bytearray` or :py:class:`memoryview`
+        or :py:class:`io.IOBase` or :py:class:`univ.OctetString`
 
     Returns
     -------
@@ -97,7 +98,7 @@ def asSeekableStream(substrate):
     if isinstance(substrate, io.BytesIO):
         return substrate
 
-    elif isinstance(substrate, bytes):
+    elif isinstance(substrate, (bytes, bytearray, memoryview)):
         return io.BytesIO(substrate)
 
     elif isinstance(substrate, univ.OctetString):

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -1829,6 +1829,20 @@ class BytesIOTestCase(BaseTestCase):
         assert values == [12, (1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1)]
 
 
+class BytearrayTestCase(BaseTestCase):
+    def testRead(self):
+        source = memoryview(bytes((2, 1, 12, 35, 128, 3, 2, 0, 169, 3, 2, 1, 138, 0, 0)))
+        values = list(decoder.StreamingDecoder(source))
+        assert values == [12, (1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1)]
+
+
+class MemoryviewTestCase(BaseTestCase):
+    def testRead(self):
+        source = bytearray((2, 1, 12, 35, 128, 3, 2, 0, 169, 3, 2, 1, 138, 0, 0))
+        values = list(decoder.StreamingDecoder(source))
+        assert values == [12, (1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1)]
+
+
 class UnicodeTestCase(BaseTestCase):
     def testFail(self):
         # This ensures that str objects cannot be parsed.


### PR DESCRIPTION
Hello there, first time contributing! I've looked for a `CONTRIBUTING.md` file or similar instructions in the README but couldn't find anything. Tell me if I'm missing anything.

The problem has been reported some years ago in issue #29, with a prior attempt at solving the problem at PR #33 but that was closed for lack of traction.

I'm a new user of the library and I was surprised it didn't accept parsing `bytearray()`. It is just a little bit inconvenient and I felt like contributing, so here is a PR to allow `bytearray()` and `memoryview()`. With a test!