### PR TITLE
Switch documentation user to pyasn1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,7 +126,7 @@ html_theme_options = {
     'logo': 'logo.svg',
     'description': '<p align=left><i><b>Brewing free software for the greater good</i></b></p>',
     'show_powered_by': False,
-    'github_user': 'etingof',
+    'github_user': 'pyasn1',
     'github_repo': 'pyasn1',
     'fixed_sidebar': True,
 }


### PR DESCRIPTION
The project moved from etingof/pyasn1 to pyasn1/pyasn1 but the github link in the documentation at
https://pyasn1.readthedocs.io/en/latest/contents.html still points at the old repository