### PR TITLE
Fix broken BitString

### DIFF
--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -667,7 +667,10 @@ class BitString(base.SimpleAsn1Type):
 
         elif isinstance(value, (tuple, list)):
             if self.namedValues and all(isinstance(v, str) for v in value):
-                bits = [self.namedValues[name] for name in value]
+                try:
+                    bits = [self.namedValues[name] for name in value]
+                except KeyError as e:
+                    raise error.PyAsn1Error('Unrecognized named value: %s' % (e.args[0],)) from e
                 value = [False] * (max(bits) + 1)
                 for i in bits:
                     value[i] = True

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -692,6 +692,18 @@ class BitString(base.SimpleAsn1Type):
                 'Bad BitString initializer type \'%s\'' % (value,)
             )
 
+    def prettyOut(self, value):
+        bit_string = bin(value)[2:]
+        bit_string = '0' * (len(value) - len(bit_string)) + bit_string
+        if self.namedValues:
+            names = []
+            for i, bit in enumerate(bit_string):
+                if bit == '1':
+                    names.append(self.namedValues.getName(i) or f'<bit {i} unnamed>')
+            return bit_string + ' (' + ', '.join(names) + ')'
+        else:
+            return bit_string
+
 
 class OctetString(base.SimpleAsn1Type):
     """Create |ASN.1| schema or value object.

--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -666,6 +666,9 @@ class BitString(base.SimpleAsn1Type):
                 return self.fromBinaryString(value, internalFormat=True)
 
         elif isinstance(value, (tuple, list)):
+            if not value:
+                return SizedInteger(0).setBitLength(0)
+
             if self.namedValues and all(isinstance(v, str) for v in value):
                 try:
                     bits = [self.namedValues[name] for name in value]

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -369,7 +369,12 @@ class BitStringTestCase(BaseTestCase):
         BaseTestCase.setUp(self)
 
         self.b = univ.BitString(
-            namedValues=namedval.NamedValues(('Active', 0), ('Urgent', 1))
+            namedValues=namedval.NamedValues(
+                ('Active', 0),
+                ('Urgent', 1),
+                ('Flagged', 2),
+                ('Blocked', 3),
+            )
         )
 
     def testBinDefault(self):
@@ -396,6 +401,9 @@ class BitStringTestCase(BaseTestCase):
         assert self.b.clone(hexValue='A98A') == (1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0)
         assert self.b.clone('1010100110001010') == (1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0)
         assert self.b.clone((1, 0, 1)) == (1, 0, 1)
+        assert self.b.clone('Blocked') == (0, 0, 0, 1)
+        assert self.b.clone('Active, Blocked') == (1, 0, 0, 1)
+        assert self.b.clone(('Active', 'Blocked')) == (1, 0, 0, 1)
 
     def testStr(self):
         assert str(self.b.clone('Urgent')) == '01'

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -408,6 +408,17 @@ class BitStringTestCase(BaseTestCase):
     def testStr(self):
         assert str(self.b.clone('Urgent')) == '01'
 
+    def testPrettyPrintNamedValues(self):
+        assert self.b.clone('Active').prettyPrint() == '1 (Active)'
+        assert self.b.clone('Urgent, Active').prettyPrint() == '11 (Active, Urgent)'
+        assert self.b.clone((1, 0, 1)).prettyPrint() == '101 (Active, Flagged)'
+        assert self.b.clone(binValue='00001').prettyPrint() == '00001 (<bit 4 unnamed>)'
+
+    def testPrettyPrint(self):
+        assert univ.BitString(binValue='1010100110001010').prettyPrint() == '1010100110001010'
+        assert univ.BitString(hexValue='A98A').prettyPrint() == '1010100110001010'
+
+
     def testRepr(self):
         assert 'BitString' in repr(self.b.clone('Urgent,Active'))
 
@@ -433,6 +444,9 @@ class BitStringTestCase(BaseTestCase):
 
     def testAsInts(self):
         assert self.b.clone(hexValue='A98A').asNumbers() == (0xa9, 0x8a), 'testAsNumbers() fails'
+
+    def testAsBinary(self):
+        assert self.b.clone(hexValue='A98A').asBinary() == '1010100110001010'
 
     def testMultipleOfEightPadding(self):
         assert self.b.clone((1, 0, 1)).asNumbers() == (5,)

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -462,6 +462,11 @@ class BitStringTestCase(BaseTestCase):
 
         assert BitString('11000000011001').asInteger() == 12313
 
+    def testUnrecognizedNamedValue(self):
+        with self.assertRaises(PyAsn1Error) as cm:
+            self.b.clone('Xyzzy')
+        self.assertEqual(str(cm.exception), 'Unrecognized named value: Xyzzy')
+
 
 class BitStringPicklingTestCase(unittest.TestCase):
 

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -467,6 +467,10 @@ class BitStringTestCase(BaseTestCase):
             self.b.clone('Xyzzy')
         self.assertEqual(str(cm.exception), 'Unrecognized named value: Xyzzy')
 
+    def testEmpty(self):
+        assert self.b.clone([]).asInteger() == 0
+        assert self.b.clone(()).asInteger() == 0
+
 
 class BitStringPicklingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
This PR adds a couple testcases for BitString that were broken for a very long time ... and fixes them :)

Namely:
* it was impossible to create a correct bitstring with multiple namedValues set, because the algorithm for setting bits was flawed
* it was not possible to use the syntax `group1 = Rights(('group-read', 'group-write'))`, explicitly mentioned in documentation, because the values would be treated as truthy bits instead of referring to namedValues

In addition, I'm adding pretty-printing of named bits.