### PR TITLE
Reject BER length values exceeding sys.maxsize

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -1718,6 +1718,12 @@ class SingleItemDecoder(object):
                         length |= lengthOctet
                     size += 1
 
+                    if length > sys.maxsize:
+                        raise error.PyAsn1Error(
+                            'Length %d exceeds maximum readable size %d' % (
+                                length, sys.maxsize)
+                        )
+
                 else:  # 128 means indefinite
                     length = -1
 

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -2155,6 +2155,19 @@ class LengthFieldLimitTestCase(BaseTestCase):
         except OverflowError:
             assert False, 'Got OverflowError instead of PyAsn1Error'
 
+    def testInRangeOctetCountButOverflowingValue(self):
+        """8-byte length whose value exceeds sys.maxsize must raise PyAsn1Error."""
+        # 0x88 = long form, 8 length octets (within the limit), value 2**64-1
+        payload = b'\x04\x88' + b'\xFF' * 8
+        try:
+            decoder.decode(payload)
+        except error.PyAsn1Error:
+            pass
+        except OverflowError:
+            assert False, 'Got OverflowError instead of PyAsn1Error'
+        else:
+            assert False, 'Overflowing length value not rejected'
+
     def testMaxAllowedLengthFieldWorks(self):
         """8-byte length field (the maximum allowed) must be accepted."""
         # 0x88 = long form, 8-byte length, value = 5


### PR DESCRIPTION
A long-form length encoded in 8 octets (within MAX_LENGTH_OCTETS) can still hold a value larger than sys.maxsize, e.g. 0xffffffffffffffff. That value reaches BytesIO.read() and raises an uncaught OverflowError instead of a PyAsn1Error, so callers guarding on PyAsn1Error miss it. Validate the decoded length and raise PyAsn1Error before the read.

Fixes: https://github.com/pyasn1/pyasn1/issues/107