### PR TITLE
Add regression tests for oversized BER length values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Revision 0.6.4, released XX-XX-2026
+---------------------------------------
+
+- Fixed OverflowError from BER/CER/DER length values that fit in the
+  supported 8-octet length field but exceed the platform maximum readable
+  size. Such oversized definite lengths are now rejected with PyAsn1Error.
+  [pr #108](https://github.com/pyasn1/pyasn1/pull/108)
+
 Revision 0.6.3, released 16-03-2026
 ---------------------------------------
 

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -2168,6 +2168,44 @@ class LengthFieldLimitTestCase(BaseTestCase):
         else:
             assert False, 'Overflowing length value not rejected'
 
+    def testLengthValueAbovePlatformLimitIsRejected(self):
+        """Length value exceeding sys.maxsize must be rejected."""
+        originalMaxsize = decoder.sys.maxsize
+        decoder.sys.maxsize = 0x7fffffff
+        try:
+            # 0x84 = long form, 4 length octets, value 2**31
+            payload = b'\x04\x84\x80\x00\x00\x00'
+            try:
+                decoder.decode(payload)
+            except error.PyAsn1Error as exc:
+                assert 'maximum readable size' in str(exc).lower(), \
+                    'Error message missing max size info: %s' % exc
+            except OverflowError:
+                assert False, 'Got OverflowError instead of PyAsn1Error'
+            else:
+                assert False, 'Length above sys.maxsize not rejected'
+        finally:
+            decoder.sys.maxsize = originalMaxsize
+
+    def testLengthValueAtPlatformLimitIsNotRejected(self):
+        """Length value equal to sys.maxsize must pass the length guard."""
+        originalMaxsize = decoder.sys.maxsize
+        decoder.sys.maxsize = 0x7fffffff
+        try:
+            # 0x84 = long form, 4 length octets, value 2**31 - 1. The
+            # payload is intentionally absent so success means EndOfStreamError.
+            payload = b'\x04\x84\x7f\xff\xff\xff'
+            try:
+                decoder.decode(payload)
+            except error.EndOfStreamError:
+                pass
+            except error.PyAsn1Error as exc:
+                assert False, 'Length equal to sys.maxsize rejected: %s' % exc
+            else:
+                assert False, 'Unexpectedly decoded payload with missing body'
+        finally:
+            decoder.sys.maxsize = originalMaxsize
+
     def testMaxAllowedLengthFieldWorks(self):
         """8-byte length field (the maximum allowed) must be accepted."""
         # 0x88 = long form, 8-byte length, value = 5


### PR DESCRIPTION
Cover length values that exceed sys.maxsize while still using a supported length-field width, and document the 0.6.4 decoder fix in CHANGES.rst.