### PR TITLE
Fix recursive ASN.1 schema decoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ Revision 0.6.4, released XX-XX-2026
   supported 8-octet length field but exceed the platform maximum readable
   size. Such oversized definite lengths are now rejected with PyAsn1Error.
   [pr #108](https://github.com/pyasn1/pyasn1/pull/108)
+- Fixed regression introduced in 0.5.0 that broke decoding of recursively
+  defined ASN.1 types with tagged alternatives (e.g. LDAP Filter). A
+  placeholder `componentType` captured at instantiation is now re-resolved
+  from the class on `clone()` and `subtype()`, so a schema completed after
+  instantiation (as recursive definitions require) is picked up by codecs.
+  Recursion through untagged CHOICE alternatives was never supported and
+  remains unsupported
 
 Revision 0.6.3, released 16-03-2026
 ---------------------------------------

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -752,7 +752,7 @@ class ConstructedPayloadDecoderBase(AbstractConstructedPayloadDecoder):
 
         if asn1Spec.typeId in (univ.Sequence.typeId, univ.Set.typeId):
 
-            namedTypes = asn1Spec.componentType
+            namedTypes = asn1Object.componentType
 
             isSetType = asn1Spec.typeId == univ.Set.typeId
             isDeterministic = not isSetType and not namedTypes.hasOptionalOrDefault
@@ -900,7 +900,7 @@ class ConstructedPayloadDecoderBase(AbstractConstructedPayloadDecoder):
                         f"ASN.1 object {asn1Object.__class__.__name__} is inconsistent")
 
         else:
-            componentType = asn1Spec.componentType
+            componentType = asn1Object.componentType
 
             if LOG:
                 LOG('decoding type %r chosen by given `asn1Spec`' % componentType)
@@ -1126,7 +1126,7 @@ class ConstructedPayloadDecoderBase(AbstractConstructedPayloadDecoder):
                             f"ASN.1 object {asn1Object.__class__.__name__} is inconsistent")
 
         else:
-            componentType = asn1Spec.componentType
+            componentType = asn1Object.componentType
 
             if LOG:
                 LOG('decoding type %r chosen by given `asn1Spec`' % componentType)

--- a/pyasn1/codec/native/decoder.py
+++ b/pyasn1/codec/native/decoder.py
@@ -34,7 +34,7 @@ class SequenceOrSetPayloadDecoder(object):
     def __call__(self, pyObject, asn1Spec, decodeFun=None, **options):
         asn1Value = asn1Spec.clone()
 
-        componentsTypes = asn1Spec.componentType
+        componentsTypes = asn1Value.componentType
 
         for field in asn1Value:
             if field in pyObject:
@@ -48,7 +48,7 @@ class SequenceOfOrSetOfPayloadDecoder(object):
         asn1Value = asn1Spec.clone()
 
         for pyValue in pyObject:
-            asn1Value.append(decodeFun(pyValue, asn1Spec.componentType), **options)
+            asn1Value.append(decodeFun(pyValue, asn1Value.componentType), **options)
 
         return asn1Value
 
@@ -57,7 +57,7 @@ class ChoicePayloadDecoder(object):
     def __call__(self, pyObject, asn1Spec, decodeFun=None, **options):
         asn1Value = asn1Spec.clone()
 
-        componentsTypes = asn1Spec.componentType
+        componentsTypes = asn1Value.componentType
 
         for field in pyObject:
             if field in componentsTypes:

--- a/pyasn1/type/base.py
+++ b/pyasn1/type/base.py
@@ -499,6 +499,8 @@ class ConstructedAsn1Type(Asn1Type):
     sizeSpec = constraint.ConstraintsIntersection()
 
     def __init__(self, **kwargs):
+        self._componentTypeExplicit = 'componentType' in kwargs
+
         readOnly = {
             'componentType': self.componentType,
             # backward compatibility, unused
@@ -570,6 +572,45 @@ class ConstructedAsn1Type(Asn1Type):
     def _cloneComponentValues(self, myClone, cloneValueFlag):
         pass
 
+    @staticmethod
+    def _isComponentTypePlaceholder(componentType):
+        if componentType is None:
+            return True
+
+        if componentType is noValue or isinstance(componentType, Asn1Item):
+            return False
+
+        return not componentType
+
+    def _cloneInitializers(self):
+        initializers = self.readOnly.copy()
+
+        componentType = initializers.get('componentType')
+
+        # objects restored from pickles predating the explicitness flag are
+        # conservatively treated as explicit, keeping their frozen snapshot
+        if (self._isComponentTypePlaceholder(componentType) and
+                not getattr(self, '_componentTypeExplicit', True)):
+            # A placeholder componentType was captured from the class before
+            # a recursively defined type was completed (e.g. LDAP Filter).
+            # Leave it out so that the new instance resolves componentType
+            # from the class, which may have been given a concrete schema
+            # afterwards. An explicitly supplied componentType, placeholder
+            # or not, is preserved as given.
+            del initializers['componentType']
+
+        elif (isinstance(componentType, ConstructedAsn1Type) and
+                not getattr(componentType, '_componentTypeExplicit', True) and
+                self._isComponentTypePlaceholder(componentType.componentType) and
+                componentType.componentType is not type(componentType).componentType and
+                not self._isComponentTypePlaceholder(type(componentType).componentType)):
+            # The component schema object itself captured a placeholder
+            # that was completed on its class afterwards. Re-clone it so
+            # that the resolved schema guides decoding of the components.
+            initializers['componentType'] = componentType.clone()
+
+        return initializers
+
     def clone(self, **kwargs):
         """Create a modified version of |ASN.1| schema object.
 
@@ -595,7 +636,7 @@ class ConstructedAsn1Type(Asn1Type):
         """
         cloneValueFlag = kwargs.pop('cloneValueFlag', False)
 
-        initializers = self.readOnly.copy()
+        initializers = self._cloneInitializers()
         initializers.update(kwargs)
 
         clone = self.__class__(**initializers)
@@ -647,7 +688,7 @@ class ConstructedAsn1Type(Asn1Type):
         are supplied, a new |ASN.1| object will be created and returned.
         """
 
-        initializers = self.readOnly.copy()
+        initializers = self._cloneInitializers()
 
         cloneValueFlag = kwargs.pop('cloneValueFlag', False)
 

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -879,6 +879,48 @@ class SetOfDecoderWithSchemaTestCase(BaseTestCase):
         ) == (self.s, b'')
 
 
+class SetOfDecoderWithLateBoundComponentTypeTestCase(BaseTestCase):
+    def testDefMode(self):
+        class AttributeValueAssertion(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('attributeDesc', univ.OctetString()),
+                namedtype.NamedType('assertionValue', univ.OctetString())
+            )
+
+        class EqualityMatch(AttributeValueAssertion):
+            tagSet = AttributeValueAssertion.tagSet.tagImplicitly(
+                tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 3)
+            )
+
+        class And(univ.SetOf):
+            tagSet = univ.SetOf.tagSet.tagImplicitly(
+                tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0)
+            )
+
+        class NestedFilter(univ.Choice):
+            pass
+
+        class Filter(univ.Choice):
+            pass
+
+        Filter.componentType = namedtype.NamedTypes(
+            namedtype.NamedType('and', And())
+        )
+        NestedFilter.componentType = namedtype.NamedTypes(
+            namedtype.NamedType('equalityMatch', EqualityMatch())
+        )
+        And.componentType = NestedFilter()
+
+        asn1Object, rest = decoder.decode(
+            bytes.fromhex('a00ea30c040375696404057573657231'),
+            asn1Spec=Filter()
+        )
+
+        assert not rest
+        assert asn1Object['and'][0]['equalityMatch']['attributeDesc'] == b'uid'
+        assert asn1Object['and'][0]['equalityMatch']['assertionValue'] == b'user1'
+
+
 class SequenceDecoderTestCase(BaseTestCase):
     def setUp(self):
         BaseTestCase.setUp(self)

--- a/tests/codec/native/test_decoder.py
+++ b/tests/codec/native/test_decoder.py
@@ -86,6 +86,23 @@ class SequenceDecoderTestCase(BaseTestCase):
         assert decoder.decode({'place-holder': None, 'first-name': 'xx', 'age': 33}, asn1Spec=self.s) == s
 
 
+class SequenceDecoderWithLateBoundComponentTypeTestCase(BaseTestCase):
+    def testLateBoundSpec(self):
+
+        class LateSequence(univ.Sequence):
+            pass
+
+        s = LateSequence()
+
+        LateSequence.componentType = namedtype.NamedTypes(
+            namedtype.NamedType('name', univ.OctetString())
+        )
+
+        asn1Value = decoder.decode({'name': 'abc'}, asn1Spec=s)
+
+        assert asn1Value['name'] == b'abc'
+
+
 class ChoiceDecoderTestCase(BaseTestCase):
     def setUp(self):
         BaseTestCase.setUp(self)

--- a/tests/type/test_univ.py
+++ b/tests/type/test_univ.py
@@ -1112,6 +1112,22 @@ class SequenceOf(BaseTestCase):
         assert len(s) == 1
         assert s.getComponentByPosition(0) == self.s1.getComponentByPosition(0)
 
+    def testCloneWithNoValueComponentType(self):
+        s = univ.SequenceOf(componentType=univ.noValue)
+
+        assert s.clone().componentType is univ.noValue
+
+        s = s.subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 7))
+
+        assert s.componentType is univ.noValue
+
+    def testCloneAfterPickleKeepsComponentType(self):
+        s = pickle.loads(pickle.dumps(
+            univ.SequenceOf(componentType=univ.Sequence())
+        ))
+
+        assert s.clone().componentType is s.componentType
+
     def testSetComponents(self):
         assert self.s1.clone().setComponents('abc', 'def') == \
                self.s1.setComponentByPosition(0, 'abc').setComponentByPosition(1, 'def')
@@ -1799,6 +1815,95 @@ class SequenceWithoutSchema(BaseTestCase):
 
         assert not s.isValue
 
+    def testInheritedComponentTypeReadOnly(self):
+
+        class ParentSequence(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString())
+            )
+
+        class ChildSequence(ParentSequence):
+            pass
+
+        s = ChildSequence()
+
+        try:
+            s.componentType = namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString()),
+                namedtype.NamedType('age', univ.Integer())
+            )
+
+        except error.PyAsn1Error:
+            pass
+
+        else:
+            assert False, 'componentType instance assignment tolerated'
+
+    def testInheritedComponentTypeSnapshot(self):
+
+        class ParentSequence(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString())
+            )
+
+        class ChildSequence(ParentSequence):
+            pass
+
+        s = ChildSequence()
+
+        ParentSequence.componentType = namedtype.NamedTypes(
+            namedtype.NamedType('name', univ.OctetString()),
+            namedtype.NamedType('age', univ.Integer())
+        )
+
+        assert len(s.componentType) == 1
+        assert 'age' not in s
+
+    def testExplicitEmptyComponentTypeOverridePreserved(self):
+
+        class ParentSequence(univ.Sequence):
+            componentType = namedtype.NamedTypes(
+                namedtype.NamedType('name', univ.OctetString())
+            )
+
+        s = ParentSequence(componentType=namedtype.NamedTypes())
+
+        assert len(s.componentType) == 0
+        assert len(s.clone().componentType) == 0
+        assert len(s.clone().clone().componentType) == 0
+        assert len(s.subtype(implicitTag=tag.Tag(
+            tag.tagClassContext, tag.tagFormatConstructed, 5)).componentType) == 0
+
+        # objects restored from pickles created by older pyasn1 carry no
+        # explicitness flag and must conservatively keep their snapshot
+        del s.__dict__['_componentTypeExplicit']
+
+        assert len(s.clone().componentType) == 0
+
+    def testLateBoundComponentTypeOnExistingInstance(self):
+
+        class LateSequence(univ.Sequence):
+            pass
+
+        s = LateSequence()
+
+        LateSequence.componentType = namedtype.NamedTypes(
+            namedtype.NamedType('name', univ.OctetString())
+        )
+
+        # the existing instance consistently keeps its pre-assignment schema
+        assert len(s.componentType) == 0
+        assert 'name' not in s
+
+        # new instances, including clones of the old one, pick up the schema
+        s = s.clone()
+
+        s['name'] = 'abc'
+
+        assert s['name'] == b'abc'
+        assert 'name' in s
+        assert len(s.componentType) == 1
+
 
 class SequencePicklingTestCase(unittest.TestCase):
 
@@ -2168,6 +2273,28 @@ class Choice(BaseTestCase):
         assert s.getComponentByPosition(1, instantiate=False) == 123
         s.clear()
         assert s.getComponentByPosition(1, instantiate=False) is univ.noValue
+
+    def testLateBoundComponentTypeOnExistingInstance(self):
+
+        class LateChoice(univ.Choice):
+            pass
+
+        s = LateChoice()
+
+        LateChoice.componentType = namedtype.NamedTypes(
+            namedtype.NamedType('number', univ.Integer())
+        )
+
+        # the existing instance consistently keeps its pre-assignment schema
+        assert len(s.componentType) == 0
+
+        # new instances, including clones of the old one, pick up the schema
+        s = s.clone()
+
+        s['number'] = 123
+
+        assert s['number'] == 123
+        assert s.getName() == 'number'
 
 
 class ChoicePicklingTestCase(unittest.TestCase):


### PR DESCRIPTION
Re-resolve late-bound componentType values on clone/subtype so recursive schemas with tagged alternatives decode correctly.