### PR TITLE
fix: raise PyAsn1Error instead of IndexError on truncated BER bit strings

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -241,6 +241,11 @@ class BitStringPayloadDecoder(AbstractSimplePayloadDecoder):
                 if isinstance(component, SubstrateUnderrunError):
                     yield component
 
+            if not component:
+                raise error.PyAsn1Error(
+                    'Truncated BER bit string: no trailing bits byte'
+                )
+
             trailingBits = component[0]
             if trailingBits > 7:
                 raise error.PyAsn1Error(
@@ -286,6 +291,11 @@ class BitStringPayloadDecoder(AbstractSimplePayloadDecoder):
 
             if component is eoo.endOfOctets:
                 break
+
+            if not component:
+                raise error.PyAsn1Error(
+                    'Truncated BER bit string: no trailing bits byte'
+                )
 
             trailingBits = component[0]
             if trailingBits > 7:


### PR DESCRIPTION
## Summary

Fixes `IndexError` when decoding truncated BER-encoded bit strings. The decoder should raise a descriptive `PyAsn1Error` instead.

**Root cause:** The BER bit string decoder accesses `component[0]` to read the trailing bits count without checking if `component` is empty. Truncated BER data can produce empty components, causing `IndexError`.

**Fix:** Added empty-component checks in both `valueDecoder` and `indefLenValueDecoder` to raise `PyAsn1Error('Truncated BER bit string: no trailing bits byte')` before accessing `component[0]`.

**Reproducer:**
```python
from pyasn1.codec.ber import decoder
decoder.decode(b'\x03\x80\x60\x00\x00')
# Before: IndexError: index out of range
# After:  PyAsn1Error: Truncated BER bit string: no trailing bits byte
```

All 1261 existing tests pass.

Closes #119
