### PR TITLE
fix: wrap ValueError in asBinary() to raise PyAsn1Error

### DIFF
--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -557,8 +557,14 @@ class BitString(base.SimpleAsn1Type):
     def asBinary(self):
         """Get |ASN.1| value as a text string of bits.
         """
-        binString = bin(self._value)[2:]
-        return '0' * (len(self._value) - len(binString)) + binString
+        try:
+            binString = bin(self._value)[2:]
+            return '0' * (len(self._value) - len(binString)) + binString
+        except ValueError:
+            raise error.PyAsn1Error(
+                'Failed to convert BitString to binary: '
+                'malformed value with invalid bit length'
+            )
 
     @classmethod
     def fromHexString(cls, value, internalFormat=False, prepend=None):


### PR DESCRIPTION
## Summary

Wrap `ValueError` in `BitString.asBinary()` to raise `PyAsn1Error` instead.

When `asBinary()` is called on a malformed zero-length BIT STRING (e.g. decoded from `b'\x03\x01\x03'`), the internal `SizedInteger.__len__()` raises `ValueError` due to an invalid bit length. This propagates as an uncaught `ValueError` instead of the expected `PyAsn1Error`.

The fix wraps the binary conversion in a `try/except ValueError` and re-raises as `PyAsn1Error`, consistent with other error handling in the module (e.g. `fromHexString`).

**Reproducer:**
```python
from pyasn1.codec.ber import decoder
decoded, rest = decoder.decode(b'\x03\x01\x03')
str(decoded)  # ValueError before, PyAsn1Error after fix
```

Closes #120
