### PR TITLE
Add agent context docs, deep-dive guides and task skills

### DIFF
--- a/.agents/skills/add-test/SKILL.md
+++ b/.agents/skills/add-test/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: add-test
+description: Add a unit or regression test to pyasn1 following the suite's strict conventions. Use when writing new tests, adding a regression test for a bug fix, or creating a new test module in this repository.
+---
+
+# Adding a test
+
+Full conventions live in [docs/TESTING.md](../../../docs/TESTING.md). This is the
+working checklist. If your change establishes a new convention (an assertion
+idiom, a layout rule, a cross-codec pattern), update TESTING.md in the same
+commit. When you do, cite tests by class and method name (`SomethingTestCase`,
+`testThing`), never by line number: line numbers rot with every edit, and the
+docs are read by humans as well as agents.
+
+## 1. Decide where the test goes
+
+**Extend an existing module.** This is the default, and correct for almost every
+case. `tests/` mirrors the package, so a change in `pyasn1/codec/ber/decoder.py`
+gets a test in `tests/codec/ber/test_decoder.py`. Add a new `TestCase` class near
+related ones, or a new method to an existing class.
+
+**A new module** is justified when the behavior spans codecs and would otherwise
+be copy-pasted into four files. `tests/codec/test_encoder_no_mutation.py` is the
+precedent: it lives at the `tests/codec/` level and drives one set of cases
+through all five codec entry points.
+
+## 2. If you create a new module, complete every step
+
+Missing the last one is the classic mistake; it fails silently.
+
+- [ ] Six-line copyright header, with a new attribution line for a genuinely new
+      file: `# Copyright (c) <year>, Simon Pichugin <simon.pichugin@gmail.com>`
+- [ ] `from tests.base import BaseTestCase`, and every `TestCase` subclasses it
+- [ ] Import style copied from the **exact module you are editing**, not its
+      directory. Only `tests/test_debug.py`, `tests/codec/ber/test_decoder.py` and
+      `tests/type/test_tag.py` use `from pyasn1 import error` plus
+      `error.PyAsn1Error`; everything else, including the sibling
+      `tests/codec/ber/test_encoder.py`, uses
+      `from pyasn1.error import PyAsn1Error` plus the bare name
+- [ ] Module footer:
+      `suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])`
+      followed by the `if __name__ == '__main__':` runner
+- [ ] **Register the module in the parent `tests/**/__main__.py` suite list.**
+      Without this, `unittest discover` runs it but `python -m tests` does not.
+      Commit `ca9ec2e` had to add
+      `'tests.codec.test_encoder_no_mutation.suite'` to `tests/codec/__main__.py`
+      for exactly this reason.
+
+If you override `setUp`, call `BaseTestCase.setUp(self)` as its first statement.
+
+## 3. Write assertions in the house style
+
+Bare `assert`. No `assertRaises`, no pytest; the suite has on the order of 1,600
+bare asserts and zero `assertRaises`.
+
+Negative cases use try/except/else, with a message naming what was wrongly
+accepted:
+
+```python
+try:
+    decoder.decode(malicious_payload)
+except error.PyAsn1Error:
+    pass
+else:
+    assert 0, 'Excessive continuation octets tolerated'
+```
+
+The `else:` clause is the load-bearing part. Without it the test passes even when
+nothing raised.
+
+Constraint violations raise `pyasn1.type.error.ValueConstraintError`, which is a
+different class from `pyasn1.error.ValueConstraintError`. Catch `PyAsn1Error`
+unless you specifically mean one of them.
+
+## 4. If this is a regression test for a security fix
+
+Use the five-part template in
+[TESTING.md](../../../docs/TESTING.md#testing-a-security-fix): malicious input
+rejected, at-the-limit input still accepted, one-over-the-limit rejected, error
+message asserted, and the rejection tests mirrored into `tests/codec/cer/` and
+`tests/codec/der/`.
+
+## 5. Verify
+
+```bash
+python -Werror -m unittest discover -s tests
+```
+
+Then confirm the new module is reachable from the aggregate runner:
+
+```bash
+python -m tests
+```
+
+**The two commands must report the same number of tests** (the current count
+is pinned in [TESTING.md](../../../docs/TESTING.md)). If `python -m tests`
+reports fewer than `discover`, your module is missing from a parent
+`__main__.py`; go back to step 2.

--- a/.agents/skills/issue-pr-triage/SKILL.md
+++ b/.agents/skills/issue-pr-triage/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: issue-pr-triage
+description: Triage pyasn1 GitHub issues and pull requests. Use when asked to triage, review, respond to, or assess an issue or pull request, judge whether a report is a bug or a security problem, or evaluate an external contribution for merge readiness.
+---
+
+# Triaging issues and pull requests
+
+pyasn1 is a low-level parsing library that most people encounter as a transitive
+dependency, so reports arrive in two very different flavors: ordinary API
+confusion, and parser bugs reachable from untrusted input. Separating those two
+is the first job of triage, because they take different routes.
+
+Repository conventions used below: labels are the GitHub defaults plus a
+repo-specific `work in progress` (`bug`, `documentation`, `duplicate`,
+`enhancement`, `good first issue`, `help wanted`, `invalid`, `question`,
+`wontfix`, `work in progress`). Merged pull requests get
+a commit subject of the form `Short description (#N)`.
+
+## 1. Security screen, always first
+
+Before writing any public reply, decide whether the report describes something
+an attacker could trigger by feeding crafted bytes to a decoder.
+[SECURITY.md](../../../SECURITY.md) is the canonical qualifies/does-not-qualify
+list: apply it, don't improvise.
+
+Signals that a report may qualify: unbounded memory growth, hangs on small
+inputs, quadratic behavior, `MemoryError` or a process crash, anything where the
+*cost* is disproportionate to the input size.
+
+If it qualifies:
+
+- Do not post a reproducer, patch or analysis in the public thread.
+- Point the reporter at `SECURITY.md`, which directs them to open a private
+  GitHub security advisory.
+- Continue under the [security-fix](../security-fix/SKILL.md) skill.
+
+The boundary that comes up most often: a *wrong exception type* is an ordinary
+public bug, per SECURITY.md and as issues #54, #119 and #120 were handled. It
+stops being ordinary when disproportionate work happens *before* the exception;
+in that case the work is the vulnerability, not the raise. Judge by what happens
+before the raise, not by the exception name.
+
+## 2. Check whether it is known, or already fixed
+
+Three places, in order:
+
+- The pending `released XX-XX-` block at the top of `CHANGES.rst`. A fix may be
+  merged but unreleased, which is exactly what a reporter testing the latest
+  PyPI release would not see. This explains a large share of reports.
+- `git log --oneline` and the released `CHANGES.rst` entries.
+- `gh issue list --state all --search "<keywords>"` and
+  `gh pr list --state all --search "<keywords>"`.
+
+If it is already fixed on `main` but unreleased, say so explicitly and name the
+commit; that is a genuinely useful answer, not a brush-off.
+
+### Recurring theme worth recognizing
+
+A large fraction of recent reports are the same defect class: a Python builtin
+exception (`ValueError`, `IndexError`, `OverflowError`) escaping where
+`PyAsn1Error` is expected, usually on truncated or malformed input. Issues #119
+and #120 and pull requests #121 and #122 are all this shape.
+
+The library's contract is that malformed input raises `PyAsn1Error` (or a
+subclass), so callers can write one `except`. These are handled publicly;
+SECURITY.md explicitly classes them as ordinary bugs. The fix is to catch the
+builtin at the point it arises and re-raise as `PyAsn1Error` with a descriptive
+message, plus a regression test. Check whether an existing issue already covers
+the same call path before opening another.
+
+## 3. Reproduce before classifying
+
+Reproduce with the CI-equivalent invocation, on `main`:
+
+```bash
+python -Werror -c "<minimal reproducer>"
+```
+
+Reduce the reporter's example to the smallest substrate or schema that still
+shows the behavior. If it does not reproduce, check the reporter's pyasn1
+version before concluding anything, and check whether they are actually hitting
+`pyasn1-modules` or a caller like `pyOpenSSL`.
+
+Then classify with a default label and, where relevant, note whether it is
+approachable enough for `good first issue`.
+
+## 4. Reviewing a pull request
+
+Most incoming pull requests are from external contributors and land as
+`Short description (#N)`. Work through this checklist; the first four items are
+the ones that most often need to be raised with the contributor.
+
+**Correctness and scope**
+
+- [ ] Does it fix the reported problem, without bundling unrelated changes?
+- [ ] For a decoder change: does it preserve the exception contract that
+      malformed input raises `PyAsn1Error`, never a bare builtin?
+
+**Cross-codec impact**: the one reviewers miss
+
+- [ ] Does it touch `pyasn1/codec/ber/`? If so it almost certainly changes CER
+      and DER too, because they derive their dispatch tables from BER with a
+      shallow copy at import time and share most payload-codec instances. See
+      the codec family section of
+      [docs/ARCHITECTURE.md](../../../docs/ARCHITECTURE.md).
+- [ ] Are there mirrored tests under `tests/codec/cer/` and `tests/codec/der/`
+      when rejection behavior changed?
+- [ ] If it registers a new type, is it added to the BER maps (which CER and DER
+      inherit at import) rather than duplicated into `cer/` and `der/`? A derived
+      `TAG_MAP` keyed by `univ.Set.tagSet` or `univ.Sequence.tagSet` silently
+      clobbers the inherited `SetOf`/`SequenceOf` entry.
+
+**CI survival**
+
+- [ ] Any new `warnings.warn(...)` in `pyasn1/`? The suite runs under `-Werror`,
+      so an unguarded warning fails every test that reaches it. This is exactly
+      why pull request #94 (`Fix broken BitString`, matejcik) cannot be merged
+      as-is: it introduces a `warnings.warn` in `BitString` initialization.
+- [ ] Python 3.8 compatible syntax only: `requires-python` is `>=3.8`.
+- [ ] No new runtime dependency. pyasn1 has none, deliberately.
+
+**Tests and conventions**
+
+- [ ] Tests present, following [docs/TESTING.md](../../../docs/TESTING.md):
+      `BaseTestCase` subclass, bare `assert`, try/except/else for negative cases.
+- [ ] A new test module is registered in the parent `tests/**/__main__.py`,
+      otherwise `python -m tests` silently skips it.
+- [ ] Import style matches the specific module edited (it varies per file, not per
+      directory).
+- [ ] If the change alters behavior documented in `AGENTS.md`, `docs/` or a
+      skill, or renames a symbol those documents cite, the same PR updates the
+      affected document. Doc references are symbols (file plus class, method
+      or constant, or a greppable expression), never line numbers, which rot
+      with every edit; the docs serve human readers as much as agents.
+
+**API compatibility**
+
+- [ ] Does it delete something that merely *looks* dead? The compatibility
+      surface section of [ARCHITECTURE.md](../../../docs/ARCHITECTURE.md) lists
+      the shims, aliases and legacy code paths that must survive. A tidy-up pull
+      request that removes them is a breaking change for downstream users and
+      should be declined with that explanation.
+- [ ] Does it "fix" a documented intentional wart? The known-warts section lists
+      them, including the `isSuperTypeOf` precedence quirk that is observable to
+      external callers passing `matchTags=False`, and the two distinct
+      `ValueConstraintError` classes.
+
+**Changelog**
+
+- [ ] An entry added to the pending `released XX-XX-` block at the top of
+      `CHANGES.rst`, referencing the pull request. Remember the file is compiled
+      into the Sphinx `-W` build, so malformed reST there fails CI.
+
+## 5. Verify locally before approving
+
+```bash
+gh pr checkout <N>
+python -Werror -m unittest discover -s tests
+```
+
+Add `tox -e docs` if the branch touches any `.rst`, `CHANGES.rst` or `docs/`
+content. See [pre-commit-check](../pre-commit-check/SKILL.md) for the full gate
+matrix.
+
+## 6. Responding
+
+Be concrete and cite evidence: file and symbol (or a permalink pinned to a
+commit), or the commit that already fixed it. When declining, explain the
+invariant that makes the change unsafe rather than just saying no; most of these
+pull requests are well-intentioned changes that happen to collide with something
+non-obvious, and the explanation is the valuable part.
+
+Credit reporters and contributors in the `CHANGES.rst` entry, with the credit at
+the end of the bullet.

--- a/.agents/skills/pre-commit-check/SKILL.md
+++ b/.agents/skills/pre-commit-check/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: pre-commit-check
+description: Run pyasn1's CI-equivalent verification before committing or pushing. Use when asked to verify changes, check whether CI will pass, run the tests before a commit, or immediately before creating any commit in this repository.
+---
+
+# Pre-commit check
+
+All of pyasn1's gates live in `tox.ini`, not in the GitHub Actions workflow.
+The workflow's tests job only installs tox and calls it; a separate `sdist`
+job re-runs `python -m build` for release artifacts, which `tox -e build`
+already covers. That means you can reproduce CI exactly on your machine, and
+it also means the obvious local command
+(`python -m unittest discover -s tests`, without `-Werror`) does not reproduce
+it.
+
+Work through the steps in order. Stop at the first failure and report it rather
+than continuing.
+
+## 1. Inspect what is staged, before anything else
+
+```bash
+git status --short
+```
+
+Read the output. If anything is staged that you did not deliberately stage,
+unstage it; this working tree has previously accumulated scratch patches,
+`.DS_Store` and lock files in the index.
+
+Two rules follow from that history:
+
+- Never run `git commit -a` or `git add -A` / `git add .` in this repository.
+- Stage with explicit pathspecs:
+  `git add pyasn1/codec/ber/decoder.py tests/codec/ber/test_decoder.py`.
+
+## 2. Always: the test suite, in CI's form
+
+```bash
+python -Werror -m unittest discover -s tests
+```
+
+`-Werror` is set on the `commands` line of `[testenv]` in `tox.ini`. Any warning
+raised anywhere during the suite is a hard failure. The suite is fast, under a
+second, so there is no reason to skip it.
+
+If you prefer the fully isolated form, `tox -e py310` runs the same command in a
+clean environment.
+
+## 3. Conditionally: the remaining gates
+
+Run the ones your diff actually touches. `tox` is not installed in a fresh
+checkout: install it (`pip install tox`) or run the underlying command directly.
+Never report a gate as passing that you were unable to run; say it was skipped
+and why.
+
+| If the diff touches… | Run | Notes |
+|---|---|---|
+| any logic in `pyasn1/` | `tox -e cover` | coverage floor is 80% (`[testenv:cover]` in `tox.ini`) |
+| any file in `pyasn1/` | `tox -e bandit` | scans `pyasn1/` only, never `tests/` |
+| any `.rst`, `CHANGES.rst`, or anything under `docs/` | `tox -e docs` | Sphinx runs with `-W`; every warning fails |
+| `pyproject.toml`, `MANIFEST.in`, `README.md` | `tox -e build` | `twine check --strict` validates README rendering |
+
+Two things to know while reading those results:
+
+`tox -e cover` does not pass `-Werror` and does not pass `-s tests`
+(the `[testenv:cover]` command in `tox.ini`), so a green coverage run is not
+evidence that the `-Werror` gate passes. Treat it as a coverage measurement only.
+
+`CHANGES.rst` is pulled into the Sphinx build via
+`.. include::` from `docs/source/changelog.rst`. A malformed changelog entry,
+say a heading underline shorter than its title or unbalanced backticks, fails
+`tox -e docs` even though the file lives at the repository root and looks like
+plain text.
+
+## 4. Codec-specific checks
+
+If the diff touches anything under `pyasn1/codec/ber/`, you have almost certainly
+changed CER and DER as well: they derive their dispatch tables from BER with a
+shallow copy at import time and share most payload-codec instances. See the codec
+family section of [ARCHITECTURE.md](../../../docs/ARCHITECTURE.md).
+
+So: confirm the cer, der and native test results in the discover run above are
+green, and if you added a decoder limit or changed rejection behavior, confirm
+there are mirrored tests under `tests/codec/cer/` and `tests/codec/der/`.
+
+## 5. Diff hygiene sweep
+
+```bash
+git diff --cached
+```
+
+Check for:
+
+- **Deprecated aliases.** No reads of the module attributes `.tagMap` or
+  `.typeMap` on a codec module. They raise `DeprecationWarning`, which is fatal
+  under `-Werror`. Use `TAG_MAP` and `TYPE_MAP`.
+- **New test modules registered.** A new `test_*.py` must also be added to the
+  `suite` list in its parent `tests/**/__main__.py`, or `python -m tests` will
+  silently never run it. See [TESTING.md](../../../docs/TESTING.md).
+- **New warnings.** Any `warnings.warn(...)` added to `pyasn1/` will fail the
+  suite under `-Werror` unless every test path that reaches it explicitly
+  expects the warning.
+- **Python 3.8 compatibility.** `requires-python` is `>=3.8`, so no `match`
+  statements, no `X | Y` type unions, no builtin generics in annotations.
+- **Changelog entry.** A user-visible behavior change needs a bullet under the
+  pending `released XX-XX-` block atop `CHANGES.rst`, and that file is reST
+  compiled under `-W`, so run `tox -e docs` after editing it (see step 3).
+- **Docs still true.** If the diff changes behavior, limits, error messages or
+  conventions described in `AGENTS.md`, `docs/ARCHITECTURE.md`,
+  `docs/TESTING.md` or a skill, or renames a symbol they cite, update the
+  affected document in the same commit. The docs reference code by symbol name,
+  so a rename orphans them silently.
+
+  When updating a document, keep its citation style: references are symbols,
+  not line numbers. Cite code by file plus class, method or constant, or by a
+  short distinctive expression to grep for. Line numbers are deliberately
+  absent: they rot with every edit, and these documents serve human readers as
+  much as agents. If a cited symbol is missing, the code has moved or changed;
+  re-verify the claim rather than deleting the reference.
+
+## 6. Confirm the push target before pushing
+
+This clone has more than one remote and they have diverged in the past; release
+tags have pointed at different commits than the local branch of the same name.
+Check `git remote -v` and `git log --oneline origin/main -1` against
+`upstream/main` before pushing anything.

--- a/.agents/skills/security-fix/SKILL.md
+++ b/.agents/skills/security-fix/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: security-fix
+description: Implement, test, and ship a pyasn1 security fix following the repository's CVE hardening conventions. Use for any vulnerability report, GHSA advisory, CVE, denial-of-service or resource-exhaustion issue, decoder limit change, downstream or RHEL backport on the 0.3.7 branch, or when generating standalone security-advisory patches.
+---
+
+# Shipping a security fix
+
+pyasn1 is a parsing library that runs on untrusted input in TLS, LDAP and
+certificate stacks, so nearly every vulnerability here is a resource-exhaustion
+or crash bug in the BER decoder reached through attacker-controlled bytes. The
+repository has a well-established shape for these fixes. Follow it.
+
+Before writing code, read the security hardening section of
+[docs/ARCHITECTURE.md](../../../docs/ARCHITECTURE.md), which inventories the
+existing limits and the recurring defect classes with their case studies.
+
+## 0. Confirm it qualifies, then keep it private
+
+[SECURITY.md](../../../SECURITY.md) is the canonical statement of what counts as
+a vulnerability in this project. Apply it before treating anything as one:
+
+- **Qualifies** (private advisory, normally a CVE): CPU, memory or stack
+  consumption disproportionate to input size; an interpreter crash; a bypass of
+  the documented `MAX_*` limits; malformed input silently decoding to a wrong
+  value.
+- **Does not qualify** (ordinary public fix; use the
+  [issue-pr-triage](../issue-pr-triage/SKILL.md) skill instead): an exception on
+  malformed input; the wrong exception type *unless* disproportionate work
+  happens before it; resource use linear in input size; anything requiring a
+  hostile schema; the documented CER/DER strictness gaps; timing variation.
+
+If a genuinely exploitable report arrived as a public issue, say so and stop:
+`SECURITY.md` directs reporters to a private GitHub security advisory. Do not
+post reproducers, patches or analysis in a public thread before the advisory
+exists.
+
+## 1. Check whether it is already fixed
+
+Several reports duplicate existing mitigations or describe something already
+fixed but not yet released.
+
+- Read the `MAX_*` constants at the top of `pyasn1/codec/ber/decoder.py`.
+- Search `CHANGES.rst` for the defect class and for existing CVE identifiers.
+- Check the pending `released XX-XX-` block at the top of `CHANGES.rst`: a fix
+  may be on `main` but unreleased, which is why a reporter testing the latest
+  PyPI release still reproduces it.
+
+Reproduce against `main` and against the latest release before concluding
+anything.
+
+## 2. Write the fix in the established shape
+
+A hardening fix in the decoder consists of five things:
+
+1. **A named module-level constant** at the top of
+   `pyasn1/codec/ber/decoder.py`, alongside the existing limits, with a comment
+   explaining what the number defends against and why that value. Follow the
+   naming already there: `MAX_TAG_OCTETS`, `MAX_NESTING_DEPTH`,
+   `MAX_LENGTH_OCTETS`, `MAX_OID_ARC_CONTINUATION_OCTETS`.
+2. **A rejection that raises `error.PyAsn1Error`**, never a bare builtin
+   exception. Callers catch `PyAsn1Error`; an `OverflowError` or `MemoryError`
+   escaping the decoder is itself the bug. Interpolate the limit into the
+   message so the diagnostic is actionable.
+3. **Enforcement inside the loop**, with an explicit counter rather than a
+   post-hoc check on an already-materialized value. The point is to stop
+   before the expensive thing happens.
+4. **Tests**, per step 3 below.
+5. **A documentation update.** Add the limit to the security-hardening
+   inventory in [docs/ARCHITECTURE.md](../../../docs/ARCHITECTURE.md) (the
+   table row plus, for a new defect class, a guardrail bullet) and keep the
+   decoder-limits invariant in `AGENTS.md` accurate if the constant set
+   changes. Cite code by symbol (class, method or constant) or a short
+   greppable expression, never by line number: line numbers rot with every
+   edit, and these documents serve human readers as much as agents.
+
+Two structural facts should stay in view while editing. CER and DER inherit
+these limits by importing the BER decoder module, and there is no per-codec
+override hook: one constant protects all three codecs, and weakening it weakens
+all three. The sharing goes beyond the constants, too. Most payload-decoder
+instances are literally shared between BER, CER and DER through a shallow
+`.copy()` of the dispatch tables at import time, so changing a BER payload
+decoder changes DER, which is what signature verification depends on.
+
+### Defect-class guardrails
+
+Every one of these has already caused a CVE in this codebase. Check your fix
+does not reintroduce one, and check the surrounding code while you are there:
+
+- **No quadratic accumulation.** In any loop over attacker-controlled octets,
+  accumulate into a `list` and convert once at the end. Never `result += (x,)`
+  on a tuple: that reallocates on every arc and turns a large OID into a denial
+  of service.
+- **No unbounded loops over the substrate.** Any `while` loop consuming octets
+  needs an explicit counter checked against a limit.
+- **No unbounded integer materialization.** Do not evaluate `pow(base, exp)`,
+  `10 ** n` or `x << n` where the exponent comes from the input. Use
+  `math.ldexp` for base 2 and range-check base-10 exponents against
+  `sys.float_info.max_10_exp`. Use floor division, not true division, when
+  normalizing integer mantissas.
+- **No plain `str()` of a possibly-huge integer.** Python 3.11+ raises
+  `ValueError` past `sys.get_int_max_str_digits()`, so a repr or error message
+  built from a tag ID or arc value must go through a hex fallback. `_tagIdToStr`
+  in `pyasn1/type/tag.py` is the existing helper.
+- **Forward the options dictionary.** Recursion depth rides in
+  `options['_nestingLevel']`. Any code path that builds a fresh options dict
+  instead of passing the existing one through resets the counter and defeats
+  the nesting-depth mitigation entirely.
+
+## 3. Tests
+
+Use the five-part template in
+[docs/TESTING.md](../../../docs/TESTING.md#testing-a-security-fix): the
+malicious substrate is rejected, input exactly at the limit still decodes, one
+over the limit is rejected, the error message is asserted, and the rejection
+tests are mirrored into `tests/codec/cer/test_decoder.py` and
+`tests/codec/der/test_decoder.py`.
+
+The at-the-limit test is not optional padding. It is the only thing that
+distinguishes a fix from a regression that breaks legitimate data.
+
+Verify with the CI form, since a new `warnings.warn` or an unexpected
+`DeprecationWarning` is fatal:
+
+```bash
+python -Werror -m unittest discover -s tests
+```
+
+## 4. Land it
+
+Fixes for embargoed advisories are developed in the private fork GitHub creates
+for a security advisory and merged from there. The resulting merge commit
+carries GitHub's default subject, literally `Merge commit from fork`, usually
+with no body; this is expected, not sloppiness.
+
+CVE and GHSA identifiers do not appear in the code or the merge commit. They
+are added to `CHANGES.rst` at release time. The entry format is:
+
+```
+- CVE-YYYY-NNNNN (GHSA-xxxx-xxxx-xxxx): <what was fixed and how> (thanks
+  for reporting, <handle>)
+```
+
+Put the reporter credit at the end of the bullet. The shipped 0.6.4 entry has
+one inserted mid-sentence, splitting the description in half; do not copy that.
+
+## 5. Standalone advisory patches
+
+`security-advisory-patches/` holds one `git format-patch` file per advisory, so
+each fix can be handed to a distributor independently. These are untracked
+working artifacts (`.gitignore` excludes `*.patch`) passed to distributors out
+of band, not committed.
+
+Generate them one advisory at a time, each rebased onto the base it is meant to
+apply to; their bases intentionally differ. Regenerating the directory as a
+single `format-patch` series would renumber them into a dependent chain and
+silently change which trees they apply to.
+
+## 6. Downstream backports
+
+There is a long-lived `0.3.7` branch carrying backports for distributions
+shipping that ancient release (Red Hat's packaging, among others).
+
+Port the fix; do not cherry-pick it. The 0.3.7 API predates the 0.4 rewrite:
+simple types derive from `base.AbstractSimpleAsn1Item` rather than
+`SimpleAsn1Type`, and octet handling goes through the removed
+`pyasn1.compat.octets` helpers (`ints2octs`, `str2octs`, `null`). A cherry-pick
+will either conflict or, worse, apply cleanly into code that no longer means the
+same thing.
+
+Export the result as an RPM-ready patch named for the release and identifier,
+in the style of the existing `python-pyasn1-0.3.7-CVE-2026-59886.patch`.
+
+Run the branch's own tests after backporting; the old suite predates several
+conventions used on `main`.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,19 @@ docs/source/.templates/layout.html
 
 # Virtual envs
 venv*
+.venv/
+
+# macOS
+.DS_Store
+
+# Advisory patches and downstream backports: generated with git format-patch
+# and passed to distributors out of band, never committed
+*.patch
+*.diff
+
+# Lock files from tooling this project does not use (pyasn1 has no runtime deps)
+uv.lock
+
+# Agent tooling: skills under .agents/ and the .claude/skills symlink are
+# tracked on purpose; only machine-local agent settings are ignored.
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,193 @@
+# AGENTS.md
+
+Canonical agent context. `CLAUDE.md` is a symlink to this file; edit only
+`AGENTS.md`. pyasn1 implements ASN.1 types (ITU-T X.680) and BER/CER/DER
+codecs (ITU-T X.690) in pure Python: zero runtime dependencies, Python 3.8+
+including PyPy, packaged from `pyproject.toml`, version single-sourced at
+`pyasn1/__init__.py`.
+
+## Where things are documented
+
+| Topic | Document |
+|---|---|
+| Subsystem deep-dives, diagrams, invariant rationale | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Security limits, CVE inventory, defect classes | [§ Security hardening inventory](docs/ARCHITECTURE.md#security-hardening-inventory) |
+| What is (and is not) a security vulnerability; reporting | [SECURITY.md](SECURITY.md) |
+| API that looks removable but is not; oddities not to "fix" | [§ Compatibility surface](docs/ARCHITECTURE.md#compatibility-surface-looks-dead-is-not), [§ Known warts](docs/ARCHITECTURE.md#known-warts-intentional) |
+| Test conventions, gates, security-test template | [docs/TESTING.md](docs/TESTING.md) |
+| Changelog (reST, compiled into the `-W` Sphinx build) | `CHANGES.rst` |
+| Task procedures | `.agents/skills/`: `issue-pr-triage`, `security-fix`, `pre-commit-check`, `add-test` |
+
+`docs/*.md` and root `*.md` sit deliberately outside the Sphinx source tree
+(`docs/source/`, `.rst` only). Do not move them there, since Markdown is
+silently ignored, and do not convert them to `.rst`: an `.rst` missing from a
+toctree fails the `-W` build.
+
+These documents are read by humans as well as agents, and they are part of the
+change surface. A diff that alters behavior, limits, error messages,
+conventions or invariants they describe, or renames a symbol they cite,
+updates the affected document in the same commit. References are by symbol
+(file plus class, method or constant) or a short greppable expression, never
+by line number: line numbers rot with every edit. If a cited symbol is
+missing, the code has moved or changed; re-verify the claim and update the
+document in the same change.
+
+## Commands
+
+```bash
+# The suite as CI runs it. -Werror lives in tox.ini, not the workflow, so a plain
+# `python -m unittest` passes on changes that fail CI.
+python -Werror -m unittest discover -s tests
+python -m unittest tests.type.test_univ   # one module
+
+tox -e py310     # same suite, isolated env
+tox -e cover     # coverage floor 80% -- runs WITHOUT -Werror and without -s tests
+tox -e bandit    # scans pyasn1/ only, never tests/
+tox -e docs      # Sphinx -W: every warning is an error
+tox -e build     # build + twine check --strict (validates README rendering)
+```
+
+`tox` is not installed in a fresh checkout: install it or run the gate
+directly, and never report a gate green that you did not run. Before
+committing, use the `pre-commit-check` skill, which sequences these with their
+skip conditions.
+
+## Repository map
+
+Layout mirrors expectations (`tests/` mirrors the package, `docs/source/` is
+Sphinx `.rst` only); full module map in ARCHITECTURE.md. The parts people get
+wrong: `type/univ.py` holds the universal types looked for elsewhere,
+`ObjectIdentifier` and `Real` included, while `type/useful.py` is only
+`ObjectDescriptor` plus the time types and character strings live in
+`type/char.py`; `type/base.py` has the spine `Asn1Item` → `Asn1Type` →
+`{SimpleAsn1Type, ConstructedAsn1Type}`; `type/error.py` holds a *second*
+`ValueConstraintError`; and `codec/streaming.py` is the resumable-stream
+engine the BER/CER/DER family runs on (the native codec does not use it).
+
+## Critical invariants
+
+Most map to a CVE or a shipped regression; the rest are frozen warts that
+downstream callers depend on. Rationale in
+[ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+- **Editing BER edits DER.** DER imports CER imports BER, and each derived
+  codec copies the parent's `TAG_MAP`/`TYPE_MAP` *shallowly* at import: 22 of
+  26 payload-decoder and 22 of 27 payload-encoder `TAG_MAP` instances are the
+  same objects in all three codecs, and the derived *decoder* `TYPE_MAP`s are
+  inherited wholesale. Editing a BER payload codec, or setting an attribute on
+  one of those instances, changes DER, which signature verification depends
+  on. Conversely, registering a new type in the BER source is enough; only
+  *runtime* mutation after import fails to propagate. Add to `cer/` or `der/`
+  only when that codec needs different behavior.
+- **CER/DER decoder strictness does not fire on the schema-driven path**,
+  because the fully inherited `TYPE_MAP` is consulted before `TAG_MAP`
+  whenever an `asn1Spec` is supplied. DER's `supportConstructedForm=False` and
+  CER's canonical Boolean check are inert there; only
+  `supportIndefLength=False` is unconditional. Test strictness changes both
+  with and without a schema.
+- **Do not weaken the decoder limits.** `MAX_OID_ARC_CONTINUATION_OCTETS`,
+  `MAX_TAG_OCTETS`, `MAX_NESTING_DEPTH` and `MAX_LENGTH_OCTETS` sit at the top
+  of `pyasn1/codec/ber/decoder.py`; the unnamed `length > sys.maxsize` guard
+  is enforced inline in the `stDecodeLength` state handling of
+  `SingleItemDecoder.__call__`. There is no per-codec override hook: one
+  constant protects all three codecs.
+- **`eoo.endOfOctets` is compared with `is`, never `==`.** It is a singleton
+  whose `defaultValue` is `0`, so `==` is true against a decoded `Integer(0)`
+  and would truncate an indefinite-length container silently, with no
+  exception.
+- **Forward the options dict.** Recursion depth rides in
+  `options['_nestingLevel']`, not the call stack; a freshly built options dict
+  defeats the nesting-depth fix.
+- **The streaming idiom is load-bearing.** Reads are written as `for chunk in
+  readFromStream(...): if isinstance(chunk, SubstrateUnderrunError): yield chunk`
+  then use the leaked loop variable. Rewriting it as `next()` or a
+  comprehension breaks resumable decoding of partial input. Decoders are
+  generators throughout; turning a `yield` into a `return` breaks the
+  pipeline.
+- **`typeId` comes from a global counter at class-definition time.**
+  Reordering classes renumbers everything after them, which is safe in-process
+  (the maps are built from `univ.X.typeId` at import) but not across versions
+  or pickles. What does corrupt dispatch is a *duplicate* `typeId`: a subclass
+  that omits its own `typeId = ...getTypeId()` line inherits its parent's and
+  silently steals its slot.
+- **Never read the deprecated `tagMap`/`typeMap` module attributes**: they
+  raise `DeprecationWarning`, fatal under `-Werror`. Use `TAG_MAP`/`TYPE_MAP`.
+- **`isSuperTypeOf`'s missing parentheses matter to callers**, not to the
+  decoder: `matchTags=False` short-circuits the check to `True`. The decoder
+  also passes `verifyConstraints=False`, where both readings agree, so
+  "fixing" the precedence is a narrow API break rather than a repo-wide decode
+  change, but still a break.
+- **Two `ValueConstraintError` classes exist.** Violations raise the one in
+  `pyasn1.type.error`, which is *not* an instance of
+  `pyasn1.error.ValueConstraintError`. Only `except PyAsn1Error` catches both.
+- **Encoders must not mutate what they encode:** iterate with
+  `getComponentByPosition(idx, instantiate=False)` and branch on `noValue`,
+  never materializing an absent DEFAULT/OPTIONAL component. Pinned by
+  `tests/codec/test_encoder_no_mutation.py`.
+- **Decoder code reads `asn1Object.componentType`, never
+  `asn1Spec.componentType`**, so recursive schemas completed after
+  instantiation still resolve. Encoders deliberately still read
+  `asn1Spec.componentType`; do not "fix" them to match.
+- **Denial-of-service guardrails on attacker-controlled input:** accumulate
+  into a list and convert once (never `tuple += (x,)`); never evaluate
+  `pow`/`**`/`<<` with an *unbounded* input-derived exponent, bounding it
+  first the way `Real.__float__` does; route `str()` of a possibly-huge
+  integer through a hex fallback, since Python 3.11+ raises past
+  `sys.get_int_max_str_digits()`.
+- **`subtype()` *accumulates* every keyword; `clone()` *replaces*.** That is
+  right for `subtypeSpec` and wrong for everything else:
+  `OctetString('abc').subtype(encoding='utf-8').encoding` is the string
+  `'iso-8859-1utf-8'`. Use `clone()` for non-constraint attributes.
+  No-argument `clone()`/`subtype()` on a simple type returns `self`;
+  constructed types always copy. Unknown encode/decode keyword arguments are
+  silently swallowed, so a misspelled option is a no-op.
+
+## Coding rules
+
+- Python 3.8-compatible syntax only: no `match`, no `X | Y` unions, no builtin
+  generics.
+- Never add a runtime dependency.
+- No linter, formatter or `CONTRIBUTING.md` exists: match the surrounding
+  file's style exactly, including its import spelling, which varies per file
+  rather than per directory. New files carry the six-line copyright header
+  used throughout the tree.
+- Changelog entries go under the pending `released XX-XX-` block atop
+  `CHANGES.rst`; dates are day-first (`08-07-2026` is 8 July 2026) and each
+  heading underline must be at least as long as its title.
+
+## Testing
+
+Subclass `tests.base.BaseTestCase`: its `setUp` enables every debug flag with
+a no-op printer, so the suite executes every `if LOG:` branch with output
+discarded and a broken logging format string is a test failure. If you
+override `setUp`, call `BaseTestCase.setUp(self)` first. Use bare `assert`;
+there is no `assertRaises` and no pytest. Negative cases use `try: ... except
+PyAsn1Error: pass else: assert 0, '... tolerated'`. A new test module must
+also be registered in the parent `tests/**/__main__.py`, or `python -m tests`
+silently never runs it. Full conventions and the five-part security-test
+template: [docs/TESTING.md](docs/TESTING.md).
+
+## Git and workspace hazards
+
+- **Never `git commit -a` or `git add -A`.** Stage explicit pathspecs and read
+  `git status --short` first; this tree has collected scratch patches before.
+- **Scope searches to `pyasn1/`, `tests/`, `docs/`**: a stale copy of the
+  package can sit under `build/lib/` beside a local `.venv/`, so repo-wide
+  grep returns phantom matches with wrong line numbers.
+- **Branch `0.3.7` is the downstream backport line** on the pre-0.4 API: never
+  merge it toward `main`, and port fixes onto it rather than cherry-picking.
+- **Confirm the push target**: this clone has diverging remotes, and release
+  tags have pointed at different commits than the local branch of the same
+  name.
+
+## Releasing
+
+Bump `__version__` in `pyasn1/__init__.py` and nowhere else; `pyproject.toml`
+and `docs/source/conf.py` read it dynamically. Date the shipping section of
+`CHANGES.rst` as `Revision X.Y.Z, released DD-MM-YYYY`, newest first; to ship
+security-only, rename the pending block to the next minor and insert a fresh
+dated block beneath it. Commit exactly those two files with subject
+`Prepare release X.Y.Z`, tag annotated `vX.Y.Z` with message `Release X.Y.Z`,
+then dispatch `.github/workflows/pypi.yml` manually, TestPyPI first. Run
+`tox -e docs` before tagging: `CHANGES.rst` is compiled into the Sphinx build,
+so malformed reST there fails CI.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Revision 0.7.0, released XX-XX-2026
   preserves component absence when inspected with ``instantiate=False``.
   Applications relying on ``encode()`` to populate defaulted components
   should explicitly instantiate or set those components before encoding.
+- Expanded SECURITY.md with the project's vulnerability scope: what
+  qualifies for a private advisory and a CVE versus what is handled
+  as an ordinary public bug report
+  [issue #96](https://github.com/pyasn1/pyasn1/issues/96)
 
 Revision 0.6.4, released 08-07-2026
 ---------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,49 @@
 
 Security updates are applied only to the latest release.
 
+## What qualifies as a vulnerability
+
+pyasn1 is a parsing library routinely fed attacker-controlled bytes (TLS, LDAP
+and certificate stacks), so the line between an ordinary bug and a
+vulnerability is drawn around what crafted *input* can extract from the
+process.
+
+**Qualifies (report privately as described below):**
+
+- CPU, memory or stack consumption disproportionate to the size of the input
+  (quadratic accumulation, unbounded integer materialization, unbounded
+  recursion or nesting)
+- An interpreter crash or abort on any input
+- A bypass of the decoder's documented limits (the `MAX_*` constants in
+  `pyasn1/codec/ber/decoder.py`)
+- Malformed input silently decoding to a wrong value instead of raising
+
+**Does not qualify (open an ordinary public issue):**
+
+- An exception raised on malformed input: rejecting bad input is the decoder's
+  contract, not a defect
+- The wrong exception type, meaning a Python builtin such as `ValueError`,
+  `IndexError` or `OverflowError` escaping where `PyAsn1Error` is documented,
+  *unless* disproportionate work happens before the exception is raised, in
+  which case that work is the vulnerability
+- Resource use proportional (roughly linear) to input size
+- Anything that requires a hostile ASN.1 *schema*: schemas are trusted code
+  supplied by the application, not attacker input
+- The documented CER/DER strictness gaps on the schema-driven decoding path
+- Timing variation: pyasn1 makes no constant-time guarantees
+
+The inventory of current decoder limits and past CVEs is kept in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#security-hardening-inventory).
+
 ## Reporting a Vulnerability
 
-If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+If you have discovered a security vulnerability in this project, please
+report it privately. **Do not disclose it as a public issue.** This gives us
+time to work with you to fix the issue before public exposure, reducing the
+chance that the exploit will be used before a patch is released.
 
-Please disclose it at our [security advisory](https://github.com/pyasn1/pyasn1/security/advisories/new).
+Please disclose it at our
+[security advisory](https://github.com/pyasn1/pyasn1/security/advisories/new).
 
-This project is maintained by a team of volunteers on a reasonable-effort basis. As such, vulnerabilities will be disclosed in a best effort base.
+This project is maintained by a team of volunteers on a reasonable-effort
+basis. As such, vulnerabilities will be disclosed on a best-effort basis.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,1885 @@
+# pyasn1 architecture
+
+pyasn1 implements ASN.1 types and the BER, CER and DER codecs in pure Python.
+One decision organizes the whole library: a single object graph plays three
+roles. The same objects describe an ASN.1 type to the codecs, hold a decoded
+value, and stand as input to an encoder; the `noValue` sentinel marks which
+role an object is playing at any moment. Encoding is a pure function over that
+graph: it reads the graph and produces bytes, and never alters what it reads.
+Decoding is the inverse run as a pipeline: it clones a schema object, then
+fills the clone from a generator-driven stream that can suspend on incomplete
+input and resume when more bytes arrive.
+
+The chapters follow that shape as a build order for a reimplementer. [The
+type system](#the-type-system) builds the graph: tags, constraints, component
+schemas, and the sentinel that separates schema from value. [The codec
+family](#the-codec-family) builds the translation: one dispatch machinery
+shared by BER, CER and DER, and the points where the dialects diverge. [The
+decoder pipeline](#the-decoder-pipeline) builds the stream: the state machine
+that parses one item, the contract that lets parsing suspend and resume, and
+the limits that make hostile input safe to parse. The closing chapters are
+inventories: the [security hardening record](#security-hardening-inventory),
+the [compatibility surface](#compatibility-surface-looks-dead-is-not), and
+the [warts kept on purpose](#known-warts-intentional).
+
+## Orientation
+
+The graph, the translation and the stream all live in one small package.
+This chapter fixes the conventions the rest of the document uses to cite
+that package, maps its modules, and describes the debug hook that threads
+through all three acts.
+
+### Conventions of this document
+
+Code references are symbols, never line numbers: a file plus a class, method
+or constant, or a short distinctive expression to grep for. Line numbers are
+absent because they rot with every edit. If a cited symbol is missing, the
+code has moved or changed; re-verify the claim and update this document in
+the same change.
+
+Map sizes, entry counts and test totals are measured values: facts about the
+checkout you are reading, kept honest by the same-commit doc-update rule. If
+a number looks off, re-measure it rather than assuming the document is right.
+
+Python behavior that an invariant depends on is explained inline at its first
+load-bearing use, sized for a reader porting the library: one clause of
+language semantics, one clause naming the property a port must reproduce.
+Later uses point back to the owning section.
+
+This file is Markdown, and the Sphinx source tree takes only reST, so it sits
+at the `docs/` root where the build never looks. The docs build reads only
+`docs/source/*.rst` under `-W` (every warning is an error), so Markdown at
+the `docs/` root is invisible to it. The `MANIFEST.in` glob picks up only
+`Makefile`, `*.rst`, `*.svg` and `conf.py` under `docs/`, so root-level
+Markdown is invisible to the sdist as well. Moving this file into
+`docs/source/` would drop it from publication with no build error; converting
+it to `.rst` without a toctree entry would fail the `-W` build.
+
+Scope searches to `pyasn1/`, `tests/` and `docs/`. A stale copy of the
+package can sit under `build/lib/` beside a local `.venv/`, so an unscoped
+grep returns phantom matches with wrong line numbers.
+
+Operating rules for the repository, such as test commands, commit hygiene and
+the release procedure, live in [AGENTS.md](../AGENTS.md) and are not restated
+here.
+
+### Module map
+
+The package is thirty-two modules; four carry most of the weight:
+`type/univ.py` (~3,300 lines), `codec/ber/decoder.py` (~2,200),
+`codec/ber/encoder.py` (~960), `type/constraint.py` (~750).
+
+| Module | Role |
+|---|---|
+| `type/base.py` | The class spine: `Asn1Item` → `Asn1Type` → `{SimpleAsn1Type, ConstructedAsn1Type}`, plus the `noValue` sentinel |
+| `type/univ.py` | The core universal types: `Integer`, `Boolean`, `BitString`, `OctetString`, `Null`, `ObjectIdentifier`, `RelativeOID`, `Real`, `Enumerated`, `SequenceOf`/`SetOf`, `Sequence`/`Set`, `Choice`, `Any` |
+| `type/char.py` | Restricted character string types, mostly deriving from `AbstractCharacterString` |
+| `type/useful.py` | `ObjectDescriptor`, `TimeMixIn`, `GeneralizedTime`, `UTCTime`, nothing else |
+| `type/tag.py` | `Tag`, `TagSet`, implicit/explicit tagging, the `_tagIdToStr` hex fallback |
+| `type/tagmap.py` | `TagMap`: the present/skip/default three-way lookup the decoder runs on |
+| `type/namedtype.py` | `NamedTypes`: SEQUENCE/SET component definitions, eagerly precomputed |
+| `type/namedval.py` | `NamedValues`, the enumeration/named-bit mapping |
+| `type/constraint.py` | Constraint objects and their composition |
+| `type/opentype.py` | `OpenType`, the ANY-defined-by mapping |
+| `type/error.py` | A *second* `ValueConstraintError`, the one actually raised |
+| `codec/streaming.py` | `asSeekableStream`, `CachingStreamWrapper`, `readFromStream`: the resumable-stream engine |
+| `codec/ber/decoder.py` | The base decoder: payload decoders, the state machine, every security limit |
+| `codec/ber/encoder.py` | The base encoder |
+| `codec/ber/eoo.py` | The end-of-octets singleton |
+| `codec/cer/*`, `codec/der/*` | Derived codecs, sharing BER's objects by identity |
+| `codec/native/*` | Conversion to and from Python dicts, lists and scalars |
+| `compat/integer.py` | A single `to_bytes` helper |
+| `debug.py` | The logging facility; see [The debug hook](#the-debug-hook) |
+| `error.py` | The exception hierarchy rooted at `PyAsn1Error` |
+
+Read [The codec family](#the-codec-family) before touching anything under
+`codec/`, even if the change looks local to BER.
+
+### The debug hook
+
+`pyasn1/debug.py` is a flag-based logger consulted through a per-module
+global named `LOG`. A module opts in with `debug.registerLoggee(__name__,
+flags=...)` at import; `setLogger` then walks the registry and rebinds `LOG`
+inside each registered module with `setattr`. The payoff is that `if LOG:`
+costs one global load, not a function call, in every hot decode path.
+Replacing the rebinding with an attribute lookup adds a function call to
+every one of those paths.
+
+The test suite leans on the same hook. `tests/base.BaseTestCase.setUp`
+installs `debug.Debug('all', printer=lambda *x: None)`, every flag enabled
+with the output discarded, so the whole suite executes every `if LOG:` branch
+and a malformed logging format string is a test failure, not dead code.
+Removing the null logger from `BaseTestCase` lets a broken format string
+reach a release with no test failing; dropping its `tearDown` leaks the
+logger into unrelated tests.
+
+## The type system
+
+The object graph is the first act. Everything in `pyasn1/type/` serves one
+job: give the codecs a machine-readable description of an ASN.1 type that is
+also a container for a decoded value. Schema and value are the same Python
+classes, distinguished at runtime by a sentinel, and that single decision
+explains most of the strangeness in this layer. The diagram below draws the
+layer whole: the class spine in `base.py`,
+the derivation graph of the simple and constructed types, and the two-tier
+dispatch the codecs run over it.
+
+```mermaid
+flowchart TB
+
+  subgraph SPINE["Class spine - pyasn1/type/base.py"]
+    AI["Asn1Item<br/>global typeId counter"]
+    AT["Asn1Type<br/>tagSet + subtypeSpec"]
+    SAT["SimpleAsn1Type<br/>_value payload"]
+    CAT["ConstructedAsn1Type<br/>componentType"]
+    AI --> AT
+    AT --> SAT
+    AT --> CAT
+  end
+
+  subgraph SIMPLE["Simple types - univ / char / useful"]
+    INT["univ.Integer"]
+    BOOL["univ.Boolean"]
+    ENUM["univ.Enumerated"]
+    BS["univ.BitString"]
+    OID["univ.ObjectIdentifier"]
+    ROID["univ.RelativeOID"]
+    REAL["univ.Real"]
+    OS["univ.OctetString"]
+    NUL["univ.Null"]
+    ANY["univ.Any<br/>UNTAGGED"]
+    ACS["char.AbstractCharacterString"]
+    TELE["char.TeletexString"]
+    T61["char.T61String"]
+    VIS["char.VisibleString"]
+    ISO["char.ISO646String"]
+    GRAPH["char.GraphicString"]
+    RESTCH["char.IA5String, UTF8String,<br/>BMPString, NumericString, ..."]
+    OD["useful.ObjectDescriptor"]
+    TMX["useful.TimeMixIn<br/>plain object, no ASN.1 tag"]
+    GT["useful.GeneralizedTime"]
+    UT["useful.UTCTime"]
+
+    INT --> BOOL
+    INT --> ENUM
+    OS --> NUL
+    OS --> ANY
+    OS --> ACS
+    ACS --> TELE
+    ACS --> VIS
+    ACS --> GRAPH
+    ACS --> RESTCH
+    TELE --> T61
+    VIS --> ISO
+    VIS --> GT
+    VIS --> UT
+    GRAPH --> OD
+    TMX -.-> GT
+    TMX -.-> UT
+  end
+
+  subgraph CONS["Constructed types - univ"]
+    SOSO["SequenceOfAndSetOfBase"]
+    SEQOF["SequenceOf<br/>tag 0:32:16"]
+    SETOF["SetOf<br/>tag 0:32:17"]
+    SASB["SequenceAndSetBase"]
+    SEQ["Sequence<br/>tag 0:32:16"]
+    SET["Set<br/>tag 0:32:17"]
+    CHO["Choice<br/>UNTAGGED"]
+    SOSO --> SEQOF
+    SOSO --> SETOF
+    SASB --> SEQ
+    SASB --> SET
+    SET --> CHO
+  end
+
+  SAT --> INT
+  SAT --> BS
+  SAT --> OS
+  SAT --> OID
+  SAT --> ROID
+  SAT --> REAL
+  CAT --> SOSO
+  CAT --> SASB
+
+  subgraph DISPATCH["Two-tier codec dispatch - decoder SingleItemDecoder.__call__ stGetValueDecoderByAsn1Spec block, encoder SingleItemEncoder.__call__"]
+    IN["chosenSpec for this TLV"]
+    Q1{"TYPE_MAP has<br/>chosenSpec.typeId"}
+    Q2{"TAG_MAP has<br/>base tagSet"}
+    HIT["concrete payload codec"]
+    MISS["stTryAsExplicitTag<br/>or PyAsn1Error"]
+    IN --> Q1
+    Q1 -->|hit| HIT
+    Q1 -->|miss| Q2
+    Q2 -->|hit| HIT
+    Q2 -->|miss| MISS
+  end
+
+  AMB["AMBIGUOUS BY TAGSET<br/>Sequence vs SequenceOf share 0:32:16<br/>Set vs SetOf share 0:32:17"]
+  UNT["UNTAGGED - no usable TAG_MAP key<br/>Choice and Any"]
+
+  SEQ --> AMB
+  SEQOF --> AMB
+  SET --> AMB
+  SETOF --> AMB
+  CHO --> UNT
+  ANY --> UNT
+  AMB -->|typeId disambiguation is mandatory| Q1
+  UNT -->|typeId disambiguation is mandatory| Q1
+```
+
+In the diagram's derivation graph, `Boolean` and `Enumerated` derive from
+`Integer`; `Null`, `Any` and `AbstractCharacterString` derive from
+`OctetString`; `T61String` derives from `TeletexString`; `ISO646String`,
+`GeneralizedTime` and `UTCTime` derive from `VisibleString`; and
+`ObjectDescriptor` derives from `GraphicString`. `TimeMixIn` is a plain object
+with no ASN.1 tag, mixed into the two time types. `Choice` derives from `Set`.
+
+The diagram's lower half records why dispatch cannot run on tags alone.
+`Sequence` and `SequenceOf` share tag `0:32:16` and `Set` and `SetOf` share
+`0:32:17`, so they are ambiguous by tagSet; `Choice` and `Any` are untagged,
+with no usable `TAG_MAP` key at all. For all of these, `typeId` disambiguation
+via `TYPE_MAP` is mandatory. Codec dispatch is therefore two-tier: `TYPE_MAP`
+is consulted for `chosenSpec.typeId` first, then `TAG_MAP` for the base
+tagSet, and a miss on both leads to `stTryAsExplicitTag` or `PyAsn1Error`
+(decoder: the `stGetValueDecoderByAsn1Spec` block of
+`SingleItemDecoder.__call__`; encoder: `SingleItemEncoder.__call__`).
+
+### The class spine
+
+Each of the four classes adds one concern. `Asn1Item` (`pyasn1/type/base.py`)
+is only the global `typeId` counter plus the `isinstance` marker for "is this
+a pyasn1 object at all": the `isinstance(value, base.Asn1Item)` checks in
+`univ.py`'s two `setComponentByPosition` implementations. `Asn1Type` adds the
+type identity: `tagSet`, `subtypeSpec`, and a null `typeId` placeholder.
+
+`Asn1Type.__init__` builds a `readOnly` dict from the class attributes,
+overlays every keyword argument, splats it into `self.__dict__`, and keeps the
+dict as `self._readOnly`. In Python, writing entries into `self.__dict__`
+installs each key directly as an instance attribute, bypassing the
+`__setattr__` hook; the invariant a port must reproduce is that one mapping
+both configures the object and survives as its rebuild recipe. Any constructor
+keyword becomes a frozen instance attribute: `Integer(colour='red')` is
+accepted, and there is no allow-list. Class attributes are snapshotted at
+construction, so later class mutation does not affect existing instances
+(`SequenceWithoutSchema.testLateBoundComponentTypeOnExistingInstance` in
+`tests/type/test_univ.py`). And `readOnly` is the complete recipe for
+rebuilding the object, so `clone()` and `subtype()` start from
+`self.readOnly.copy()`: directly in `SimpleAsn1Type`, via `_cloneInitializers`
+in the constructed base.
+
+`SimpleAsn1Type` adds the scalar payload and validates it eagerly:
+`SimpleAsn1Type.__init__` runs the value through `prettyIn()` and then
+`self.subtypeSpec(value)`, and that construction-time check makes simple types
+safe to treat as immutable. `ConstructedAsn1Type` adds `componentType` and
+validates nothing at construction, because a container cannot be size-checked
+while it is still being filled, as the note in `ValueSizeConstraint`'s
+docstring (`constraint.py`) spells out. Constructed types are checked only
+when someone reads `.isInconsistent`
+(`SequenceOfAndSetOfBase.isInconsistent`, `SequenceAndSetBase.isInconsistent`),
+which the encoders do on the way out.
+
+`clone()`/`subtype()` round-tripping for third-party subclasses with custom
+attributes rests on both properties: a positional parameter added to
+`Asn1Type.__init__`, or a filter that drops unknown keywords from `readOnly`,
+breaks it, along with the pickling assertions in `IntegerPicklingTestCase`
+(`tests/type/test_univ.py`).
+
+### The value sentinel
+
+`NoValue` is a singleton enforced in `__new__`. On first instantiation it
+plugs nearly every dunder method with a raise of `PyAsn1Error` (via the nested
+`getPlug` factory), so touching a schema object produces
+`Attempted "<op>" operation on ASN.1 schema object` instead of a confusing
+`TypeError` five frames later. The `skipMethods` set leaves the pickle
+protocol unplugged so the sentinel can round-trip through serialization, and
+combined with the `__new__` guard,
+`pickle.loads(pickle.dumps(base.noValue)) is base.noValue` holds.
+
+One instance has four module-level names: `base.noValue`, re-exported by
+`univ.py` (its `noValue = NoValue()` gets the singleton back from `__new__`)
+and aliased by `char.py` and `useful.py` (both `noValue = univ.noValue`). All
+four are the same object, always compared with `is`. Python's `is` tests
+object identity, a pointer comparison no class can override, where `==`
+dispatches to overridable equality methods; the invariant a port must keep is
+that the sentinel test can never be answered, or spoofed, by a value object.
+
+`isValue` reads the sentinel differently per shape: `SimpleAsn1Type` checks
+`self._value is not noValue`; `SequenceOf`/`SetOf` require a dense component
+dict with every member recursively a value (`SequenceOfAndSetOfBase.isValue`);
+`Sequence`/`Set` skip OPTIONAL/DEFAULT components
+(`SequenceAndSetBase.isValue`), so a record missing only optional fields still
+counts; `Choice.isValue` checks only the selected alternative.
+
+Anything that makes `NoValue.__new__` stop returning the singleton, such as
+adding `__slots__` or a custom `__reduce__`, breaks the `is` comparisons after
+unpickling: every empty schema starts reporting `isValue` and the encoders
+emit garbage instead of raising "component not chosen".
+
+### Type identity and dispatch keys
+
+`Asn1Item.getTypeId()` increments a class-level counter and is called in class
+bodies at definition time, from `Integer`'s
+`typeId = base.SimpleAsn1Type.getTypeId()` in `univ.py` through `UTCTime`'s in
+`useful.py`. Python executes a class body as ordinary code the first time its
+module is imported, so each of these lines runs exactly once, in import order;
+a port must reproduce the outcome, one unique identifier per concrete type,
+whatever allocation mechanism it uses. Because `char` imports `univ` and
+`useful` imports `char`, the order is deterministic, and the counter currently
+ends at 31 (`Integer=1` through `Any=15`, the `char` types 16-28, `useful`
+29-31). Treat these integers as accidents of the import graph, not constants.
+
+`GeneralizedTime` and `UTCTime` both write
+`typeId = char.VideotexString.getTypeId()`. The spelling does not reuse
+VideotexString's id, because `getTypeId` ignores its receiver and always mints
+a fresh number. "Tidying" it into `char.VideotexString.typeId` would create a
+collision.
+
+Duplicates, not renumbering, are the real hazard. Renumbering is harmless
+in-process because both codec `TYPE_MAP`s are built by reading `univ.X.typeId`
+dynamically at import (the module-level `TYPE_MAP` dicts in `decoder.py` and
+`encoder.py`): if every number shifts, every key shifts with it. A duplicate
+is different. A subclass that omits its own `typeId = ...getTypeId()` line
+inherits its parent's, with no error raised
+(`class MyAny(univ.Any): pass` gives `MyAny.typeId == 15`). If `Any` itself
+lost its `typeId = OctetString.getTypeId()` line and inherited `OctetString`'s
+4, the decoder's backfill guard
+`if typeId is not None and typeId not in TYPE_MAP` would let `Any` claim key 4
+first, and every schema-driven OCTET STRING decode would be routed to
+`AnyPayloadDecoder`.
+
+The counter is also shared with any downstream package that subclasses a
+pyasn1 type, so a given `typeId`'s numeric value depends on the application's
+full import graph. Never persist one, never hardcode one, never compare across
+processes; always spell it `univ.Sequence.typeId` the way
+`ConstructedPayloadDecoderBase.valueDecoder` does. Dropping or duplicating a
+`typeId = ...getTypeId()` line raises nothing: it rebinds a payload codec, and
+the failure surfaces far downstream as a wrong-class object.
+
+`TYPE_MAP` is not exhaustive by design. It holds 28 entries and legitimately
+lacks `Enumerated`, `T61String` and `ISO646String`, which fall through to the
+`TAG_MAP` base-tag lookup in `SingleItemDecoder.__call__`; a `KeyError` there
+is normal control flow, not a bug.
+
+### Identity frozen, value mutable
+
+`Asn1Type.__setattr__` is the whole of the immutability enforcement:
+
+```python
+# pyasn1/type/base.py, Asn1Type.__setattr__: the entire guard
+def __setattr__(self, name, value):
+    if name[0] != '_' and name in self._readOnly:
+        raise error.PyAsn1Error('read-only instance attribute "%s"' % name)
+    self.__dict__[name] = value
+```
+
+The operand order is load-bearing: `name[0] != '_'` must come first, because
+`self._readOnly` is itself assigned through this method (the last line of
+`Asn1Type.__init__`) and does not exist yet at that moment. The same
+short-circuit lets subclasses set private state before calling up
+(`SequenceOfAndSetOfBase.__init__` setting `_componentValues`,
+`ConstructedAsn1Type.__init__` setting `_componentTypeExplicit`). And the
+guard covers only names in `readOnly`; everything else is fair game.
+
+So the "immutable" objects are mutated constantly, through underscore names:
+`_value` (set by `SimpleAsn1Type.__init__`), `_componentValues` (both
+`setComponentByPosition` implementations), `_componentTypeLen` and
+`_dynamicNames` (`SequenceAndSetBase.__init__`), `Choice._currentIdx`
+(`Choice.setComponentByPosition`). Even `Any` memoizes `tagMap` into
+`self._tagMap`, so `a.tagMap is a.tagMap` is `True` for `Any` but `False` for
+`Integer`, whose `tagMap` comes from the base `Asn1Type.tagMap` property and
+allocates fresh on every access. "Immutable" here means the ASN.1 type
+identity is frozen; the value is not, and the decoder depends on filling a
+cloned schema object in place.
+
+Every constructed decode depends on this gap: the decoder writes into the
+`asn1Spec.clone()` that `ConstructedPayloadDecoderBase.valueDecoder` makes on
+nearly every constructed TLV, so putting the underscore names into `readOnly`,
+or making `_componentValues` public, turns each of those writes into a
+`read-only instance attribute` error.
+
+### Deriving types: clone and subtype
+
+For simple types, both `clone()` and `subtype()` return `self` when called
+with no arguments. Constructed types always allocate; component values are
+copied only with `cloneValueFlag=True`. Both methods rebuild from the
+`readOnly` recipe described in [The class spine](#the-class-spine).
+
+The substantive difference: `clone` replaces extra keywords
+(`initializers.update(kwargs)`); `subtype` adds them
+(`initializers[arg] += option`). Adding is what makes `subtype(subtypeSpec=...)`
+express ASN.1 subtyping, since the new constraint intersects with the
+inherited one. But the `+=` applies to every keyword, a genuine wart for
+non-constraint attributes:
+`univ.OctetString('abc').subtype(encoding='utf-8').encoding` is the string
+`'iso-8859-1utf-8'`. Use `clone()` for anything that is not a constraint.
+
+Tag keywords are special-cased before the `+=` loop. `implicitTag` routes to
+`TagSet.tagImplicitly`, which replaces the last super-tag while preserving its
+format bits; `explicitTag` routes to `TagSet.tagExplicitly`, which appends and
+forces the constructed format, because an EXPLICIT tag wraps a nested TLV. On
+`univ.Integer()`: `implicitTag=Tag(context, simple, 5)` yields the single tag
+`[128:0:5]`; `explicitTag=...` yields `[0:0:2]` followed by `[128:32:5]`.
+
+One invariant underpins all tag handling: `Tag` equality and hashing use only
+`(tagClass, tagId)` and exclude `tagFormat`, so a tag keeps the same map key
+whether it arrives in simple or constructed form. `Tag.__init__` precomputes
+that pair and its hash, and `__eq__` through `__hash__` compare nothing else.
+`Tag(universal, simple, 4) == Tag(universal, constructed, 4)` is `True` with
+equal hashes, and that equality is what lets the decoder look up a
+constructed-form OCTET STRING in a `TAG_MAP` keyed by the simple form.
+
+Making `subtype` replace instead of add widens every constrained subtype in
+downstream schemas without raising anything; `pyasn1-modules` builds most of
+X.509 and SNMP out of `subtype(subtypeSpec=...)` chains. A `tagImplicitly`
+that appended would change the wire format of every IMPLICIT-tagged field,
+and a `Tag.__eq__`/`__hash__` that saw `tagFormat` would break every chunked
+and indefinite-length decode.
+
+### Tag dispatch: tagSet and TagMap
+
+`tagSet` answers "what tags identify this type". `tagMap` answers "which tags
+can appear here on the wire, and which schema object should each be handed
+to". For ordinary types `Asn1Type.tagMap` is a one-entry map
+`{self.tagSet: self}`; it exists so every type presents the same interface to
+`NamedTypes.__computeTagMaps` (`namedtype.py`).
+
+`TagMap` (`tagmap.py`) has three slots: `presentTypes` (positive), `skipTypes`
+(negative), `defaultType` (catch-all). `TagMap.__getitem__` tries the positive
+map, raises `KeyError` on a plain miss, raises
+`PyAsn1Error('Key in negative map')` on an excluded key, and otherwise returns
+the default. The decoder catches only `KeyError` (around the
+`asn1Spec[tagSet]` lookup in `SingleItemDecoder.__call__`), so a negative-map
+hit is a hard error, not a "try something else".
+
+The untagged types are the catch-alls. `Choice`, whose class-level `tagSet` is
+an empty `tag.TagSet()`, is transparent when untagged: its `tagMap` returns
+`self.componentType.tagMapUnique`, so the decoder sees its alternatives' tags,
+and its `effectiveTagSet` similarly delegates to the selected component.
+`Any`, untagged the same way, goes further: its `tagMap` is
+`TagMap({self.tagSet: self}, {eoo tagSet: eoo}, self)`, itself as default and
+end-of-octets as the sole skipped key. So `ANY` swallows any TLV except the
+indefinite-length terminator, which must stay visible to the enclosing loop.
+
+The terminator's visibility does not actually ride on that entry:
+`SingleItemDecoder.__call__` checks for the two-byte `EOO_SENTINEL` up front,
+before any tag map is consulted, whenever the enclosing loop passes
+`allowEoo=True` — which every indefinite-length loop does. The `skipTypes`
+entry is a second line of defense: it hard-errors a stray end-of-octets TLV
+arriving where no loop said `allowEoo`, instead of letting `Any` swallow it
+as payload.
+
+### Component schemas and deferred errors
+
+`NamedTypes.__init__` computes twelve derived structures up front: tag maps,
+position maps, ambiguity tables, required components. Nothing is lazy, because
+these are consulted per component on every decode
+(`ConstructedPayloadDecoderBase.valueDecoder` reads `hasOptionalOrDefault` and
+`tagMapUnique`). The cost is quadratic construction:
+`__computeAmbiguousTypes` builds, for each field, a nested `NamedTypes`
+holding that field plus (when the field is OPTIONAL/DEFAULT) the run of
+following fields up to and including the first mandatory one, so
+`getTagMapNearPosition(idx)` can answer "what may legally appear at position
+N" in O(1). Recursion stops via the `terminal=True` keyword, checked in
+`__init__` and passed by `__computeAmbiguousTypes` for each nested
+`NamedTypes` it builds.
+
+Three of the precomputations can detect an error, and none raise. Duplicate
+names (`__computeNameToPosMap`), duplicate tags (`__computeTagToPosMap`) and
+non-unique tag maps (`__computeTagMaps`) each store a `PostponedError`, a
+four-line object whose `__getitem__` raises `PyAsn1Error`, where the dict or
+TagMap would have gone; the error surfaces on first subscript, arbitrarily far
+from the class definition that caused it. With two same-tagged fields,
+construction succeeds, `nt.tagMap` works (the non-unique variant skips the
+check; `__computeTagMaps` guards it with
+`if unique and tagSet in presentTypes`), and `nt.tagMapUnique` is a
+`PostponedError`. Even `'a' in nt.tagMapUnique` raises, because
+`PostponedError` offers only `__getitem__` and `in` falls back to it;
+`'a' in nt` itself stays healthy, since `NamedTypes.__contains__` reads the
+name map, which duplicate tags leave intact and only duplicate names poison.
+
+Deferral exists because schema class bodies run at import time and recursive
+schemas are legitimately constructed while referenced types are still
+incomplete (see [Recursive schemas](#recursive-schemas)). Raising
+immediately would make that pattern unconstructible: the first casualty in
+`SetOfDecoderWithLateBoundComponentTypeTestCase`
+(`tests/codec/ber/test_decoder.py`) is its `AttributeValueAssertion`, whose
+two OCTET STRING fields share tag `0:0:4` and produce their `PostponedError`
+while the class body is still executing. Removing the `unique` guard in
+`__computeTagMaps` turns every legitimately ambiguous SEQUENCE into a hard
+error.
+
+### Recursive schemas
+
+The late-bound componentType machinery arrived in commit `24b1697` ("Fix
+recursive ASN.1 schema decoding") for a problem that only appears in recursive
+schemas. The natural way to express recursion is to define classes first and
+wire the cross-references afterwards:
+
+```python
+# tests/codec/ber/test_decoder.py,
+# SetOfDecoderWithLateBoundComponentTypeTestCase: an LDAP Filter, abridged
+class NestedFilter(univ.Choice): pass
+class Filter(univ.Choice): pass
+Filter.componentType = NamedTypes(NamedType('and', And()))
+NestedFilter.componentType = NamedTypes(NamedType('equalityMatch', EqualityMatch()))
+And.componentType = NestedFilter()          # assigned last
+```
+
+But `ConstructedAsn1Type.__init__` snapshots the class's `componentType` into
+the instance at construction, so the `And()` embedded in `Filter.componentType`
+captured `None`; decoding against it would produce untyped components. The
+fix: `__init__` records whether the caller explicitly supplied a componentType
+(`self._componentTypeExplicit = 'componentType' in kwargs`), and
+`_cloneInitializers` (used by both `clone` and `subtype` instead of a plain
+`readOnly.copy()`) drops a never-explicit placeholder from the initializers,
+so the new instance re-reads the possibly now completed class attribute and
+re-clones a nested schema that itself captured a stale placeholder. The
+`getattr(self, '_componentTypeExplicit', True)` defaults protect objects
+unpickled from versions predating the flag
+(`SequenceWithoutSchema.testExplicitEmptyComponentTypeOverridePreserved` in
+`tests/type/test_univ.py`).
+
+Decoder code therefore reads `asn1Object.componentType`, never
+`asn1Spec.componentType`. The decoder's working object is the
+`asn1Spec.clone()` made at the top of
+`ConstructedPayloadDecoderBase.valueDecoder`'s schema-driven path, the write
+target described in
+[Identity frozen, value mutable](#identity-frozen-value-mutable), and only the
+clone has been through `_cloneInitializers`. The converted sites are the
+constructed `valueDecoder`'s reads in its `Sequence`/`Set` and
+`SequenceOf`/`SetOf` branches and the `indefLenValueDecoder` read in its
+`SequenceOf`/`SetOf` branch, plus the three container payload decoders'
+`__call__`s in `native/decoder.py`; the `indefLenValueDecoder`
+`Sequence`/`Set` branch and the Choice paths already read from `asn1Object`.
+Test coverage over the six converted reads is partial. Reverting the
+`valueDecoder` `SequenceOf`/`SetOf` read fails the LDAP-Filter test
+(`SetOfDecoderWithLateBoundComponentTypeTestCase` in
+`tests/codec/ber/test_decoder.py`), and reverting the three
+`native/decoder.py` reads fails
+`SequenceDecoderWithLateBoundComponentTypeTestCase.testLateBoundSpec` in
+`tests/codec/native/test_decoder.py`. The `valueDecoder` `Sequence`/`Set`
+read and the `indefLenValueDecoder` `SequenceOf`/`SetOf` read have no test
+that fails when they are reverted: the full suite stays green with either
+one back on `asn1Spec`.
+
+The encoder is different, and not safe. It still reads
+`asn1Spec.componentType` (`SequenceEncoder.encodeValue`,
+`SequenceOfEncoder._encodeComponents`, `ChoiceEncoder.encodeValue`) on the
+bare-Python-value-plus-schema path and never clones, so a schema instance
+captured before its class was completed encodes as if it had no components; do
+not "fix" the encoders to match the decoder (their own discipline is the
+subject of [Encoding as a pure function](#encoding-as-a-pure-function)). Such
+a stale `Sequence` encodes `{'name': 'abc'}` to `3000` (empty) where a fresh
+instance gives `30050403616263`. Pass a freshly constructed or cloned schema
+to `encode()`.
+
+An instance created before the class attribute was assigned keeps its empty
+schema forever; only a clone picks up the completed one
+(`testLateBoundComponentTypeOnExistingInstance` in both the
+`SequenceWithoutSchema` and `Choice` cases of `tests/type/test_univ.py`).
+Removing the `getattr(..., True)` defaults corrupts objects restored from
+pickles written by 0.6.4 or earlier: the flag ships first in 0.7.0 (the
+recursive-schema entry under `Revision 0.7.0` in `CHANGES.rst`), so "predating
+the flag" covers every published release to date.
+
+### The constraint algebra
+
+Constraints are a small algebra. Leaf constraints override `_testValue`;
+`ConstraintsIntersection`, `ConstraintsUnion` and `ConstraintsExclusion`
+compose them; constraint sets support `+`, the operator `subtype()` uses, its
+`initializers[arg] += option` landing in `AbstractConstraintSet.__add__` (see
+[Deriving types: clone and subtype](#deriving-types-clone-and-subtype)). An
+empty constraint is free (`AbstractConstraint.__call__` returns immediately
+when `_values` is empty), and `AbstractConstraint.isSuperTypeOf` returns
+`True` unconditionally for an unconstrained type. `WithComponentsConstraint`
+operates on a mapping, so `isInconsistent` flattens containers into dicts
+before invoking the chain (in both the `SequenceAndSetBase` and
+`SequenceOfAndSetOfBase` implementations).
+
+Two unrelated classes are named `ValueConstraintError`:
+`pyasn1.type.error.ValueConstraintError` and
+`pyasn1.error.ValueConstraintError`. Both subclass `PyAsn1Error`; neither
+subclasses the other. `constraint.py` imports the type-layer module
+(`from pyasn1.type import error`), so every constraint violation raises the
+type-layer class, and `isinstance(e, pyasn1.error.ValueConstraintError)` is
+`False`; only `except PyAsn1Error` catches both. Every `Raises` docstring in
+the type layer names the `pyasn1.error` variant, the one that is never raised
+(twelve sites: grep `~pyasn1.error.ValueConstraintError` across `univ.py` and
+`char.py`).
+
+The split is frozen. The in-repo tests import the type-layer class by name
+(`from pyasn1.type import error` in both `tests/type/test_constraint.py` and
+`tests/type/test_univ.py`), and downstream code written against the documented
+namespace catches the other. Aliasing one class to the other keeps this repo's
+tests green while changing exception routing for every downstream
+`except pyasn1.error.ValueConstraintError` block that currently never fires,
+and no test detects the change.
+
+### Type relations and their flags
+
+```python
+# pyasn1/type/base.py, Asn1Type.isSameTypeWith: the return statement
+return (self is other or
+        (not matchTags or self.tagSet == other.tagSet) and
+        (not matchConstraints or self.subtypeSpec == other.subtypeSpec))
+
+# pyasn1/type/base.py, Asn1Type.isSuperTypeOf: the return statement
+return (not matchTags or
+        (self.tagSet.isSuperTagSetOf(other.tagSet)) and
+         (not matchConstraints or self.subtypeSpec.isSuperTypeOf(other.subtypeSpec)))
+```
+
+Because `and` binds tighter than `or`, `isSuperTypeOf` parses as
+`(not matchTags) or (…)`, so `matchTags=False` short-circuits the whole method
+to `True` and constraints are never examined. `isSameTypeWith` is
+parenthesized correctly. With `matchTags=False, matchConstraints=True`, a
+constrained `Integer` reports `isSuperTypeOf(plain Integer)` as `True` while
+`isSameTypeWith` says `False`.
+
+The asymmetry is reachable from the public API. `setComponentByPosition` (both
+the `SequenceOfAndSetOfBase` and `SequenceAndSetBase` implementations) invokes
+the checker as `subtypeChecker(value, verifyConstraints and matchTags,
+verifyConstraints and matchConstraints)`, so a caller passing
+`matchTags=False` with the other flags at their defaults hits exactly the
+buggy case.
+
+The BER decoder does not depend on the parenthesization bug. Its call sites
+(the seven `matchTags=False, matchConstraints=False` calls in
+`ConstructedPayloadDecoderBase` and `ChoicePayloadDecoder`) also pass
+`verifyConstraints=False`, which folds both flags to `False`, where both
+parenthesizations agree. The decoder wants the checker bypassed entirely: a
+decoded component's tag legitimately differs from the schema's under IMPLICIT
+tagging, and constraints are re-verified later via `isInconsistent`.
+
+"Fixing" the parentheses changes nothing in this repo's test suite, but it
+starts rejecting components for every external caller that passes
+`matchTags=False` without `verifyConstraints=False`, a documented, supported
+combination described in both `setComponentByPosition` docstrings. The repair
+is an API break confined to that flag combination.
+
+### Bounded conversion of Real
+
+`Real` stores `(mantissa, base, exponent)`, base restricted to 2 or 10 in
+`Real.prettyIn`. The conversion to float used to be
+`float(mantissa * pow(base, exponent))`: all three operands arrive from the
+wire, and the intermediate integer costs time and memory proportional to the
+value of the exponent, not the length of the input (CVE-2026-59886). Python
+integers are arbitrary precision, so nothing overflows before memory runs out;
+a port with fixed-width integers meets overflow here instead. The current code
+short-circuits three ways:
+
+```python
+# pyasn1/type/univ.py, Real.__float__
+if not mantissa:
+    return 0.0
+if base == 2:
+    return math.ldexp(float(mantissa), exponent)
+# base is 10 (prettyIn() rejects everything else); refuse to
+# materialize astronomically large integers via pow()
+if exponent > sys.float_info.max_10_exp:
+    raise OverflowError('Real value too large to convert to float')
+return float(mantissa * pow(base, exponent))
+```
+
+Base 2 goes through `math.ldexp`, which adjusts the IEEE exponent field
+directly and never builds a big integer, and base 2 is the only base the BER
+binary REAL form can produce: `RealPayloadDecoder.valueDecoder` always yields
+`value = (p, 2, e)` from the binary form, folding bases 8 and 16 into the
+base-2 exponent (`e *= 3`, `e *= 4`). So the `ldexp` branch covers the entire
+binary attack surface.
+
+Base 10 arrives from all three ISO 6093 character forms: the same decoder's
+NR1 branch yields a base-10 tuple directly (`(int(chunk), 10, 0)`), while its
+NR2 and NR3 branches yield Python floats that `Real.prettyIn` converts to
+base-10 tuples. The guard there is the `max_10_exp` range check, since
+anything above it cannot be a double regardless of mantissa; it matters
+chiefly for NR1's big-integer mantissas, because NR2 and NR3 values have
+already survived Python's `float()` and fit a double. The zero-mantissa
+short-circuit is itself a fix: `(0, 10, 10**9)` is mathematically zero but
+would otherwise trigger a billion-digit `pow`. `prettyPrint()` renders
+overflow as `<overflow>` via its `except OverflowError` fallback.
+
+The companion fix is `__normalizeBase10`, which moves trailing zeros from the
+mantissa into the exponent using `m //= 10`. It was previously `/=`: true
+division loses precision above `2**53` and raises `OverflowError` for very
+large integers. Normalization running before `__float__` is also what makes
+the guard effective against padded mantissas: `(10, 10, 308)` normalizes to
+`(1, 10, 309)` and is then rejected
+(`RealTestCase.testFloatBase10NormalizedOverflow` in
+`tests/type/test_univ.py`).
+
+The `base == 2` branch is the entire binary-form defense: routed through the
+generic `pow` path instead, every binary REAL on the wire reopens the
+vulnerability, and six bytes of substrate become an unbounded allocation.
+Reverting `//=` to `/=` breaks `RealTestCase.testPrettyInBigBase10Mantissa`
+and truncates, without raising, the large mantissas that do construct. The
+encoder carries its own, older REAL bounds, inventoried under
+[Encoder guards](#encoder-guards).
+
+## The codec family
+
+The second act is the translation between the object graph and bytes. pyasn1
+ships four codecs for it, but only three are separate pieces of software:
+BER, CER and DER form one inheritance chain in which the derived modules
+mostly re-export the parent's objects, sharing by identity rather than by
+value, and that sharing crosses the line between lenient BER parsing and DER,
+the encoding that signatures are computed over. The `native` codec reuses
+the naming but shares no code. Every sharing count in the diagram and tables
+below is measured on this tree by comparing map values with `is`.
+
+The diagram maps the whole family; solid boxes are classes and maps, and the
+dotted edges are the shallow copies, labeled with the measured identity
+counts.
+
+```mermaid
+flowchart LR
+    subgraph BER["BER - pyasn1/codec/ber"]
+        direction TB
+        BEM["encoder TAG_MAP + TYPE_MAP<br/>defined from scratch"]
+        BEI["all encoder classes live here<br/>Integer OctetString BitString<br/>Sequence SequenceOf Choice Any<br/>ObjectIdentifier Real Null"]
+        BSE["SingleItemEncoder<br/>fixedDefLengthMode None<br/>fixedChunkSize None"]
+        BDM["decoder TAG_MAP + TYPE_MAP<br/>plus typeId backfill loop"]
+        BDI["BitString and OctetString decoders<br/>supportConstructedForm True"]
+        BSD["SingleItemDecoder<br/>supportIndefLength True"]
+        BEI -->|"registers"| BEM
+        BSE -->|"reads"| BEM
+        BDI -->|"registers"| BDM
+        BSD -->|"reads"| BDM
+    end
+
+    subgraph CER["CER - pyasn1/codec/cer"]
+        direction TB
+        CEM["encoder TAG_MAP + TYPE_MAP<br/>copy of BER plus update"]
+        CEO["REAL OVERRIDES<br/>BooleanEncoder emits 255<br/>RealEncoder forces value base<br/>GeneralizedTime + UTCTime<br/>SetOfEncoder padded chunk sort<br/>SetEncoder STATIC choice key<br/>SequenceEncoder omitEmptyOptionals<br/>SequenceOfEncoder ifNotEmpty"]
+        CSE["SingleItemEncoder<br/>fixedDefLengthMode False<br/>fixedChunkSize 1000"]
+        CDM["decoder TAG_MAP + TYPE_MAP<br/>copy plus backfill that adds nothing"]
+        CDO["REAL OVERRIDE<br/>BooleanPayloadDecoder<br/>accepts only 0x00 and 0xFF"]
+        CDA["aliases only - no behavior change<br/>BitString OctetString Real"]
+        CSD["SingleItemDecoder<br/>no override - inherits BER"]
+        CEO -->|"update"| CEM
+        CSE -->|"reads"| CEM
+        CDO -->|"update"| CDM
+        CDA -.->|"re-instantiated, same class"| CDM
+        CSD -->|"reads"| CDM
+    end
+
+    subgraph DER["DER - pyasn1/codec/der"]
+        direction TB
+        DEM["encoder TAG_MAP + TYPE_MAP<br/>copy of CER plus update"]
+        DEO["REAL OVERRIDE - one class only<br/>SetEncoder DYNAMIC choice key<br/>resolves the chosen alternative"]
+        DSE["SingleItemEncoder<br/>fixedDefLengthMode True<br/>fixedChunkSize 0"]
+        DDM["decoder TAG_MAP + TYPE_MAP<br/>copy plus backfill that adds nothing"]
+        DDO["REAL OVERRIDES<br/>BitString supportConstructedForm False<br/>OctetString supportConstructedForm False"]
+        DSD["SingleItemDecoder<br/>supportIndefLength False"]
+        DEO -->|"update"| DEM
+        DSE -->|"reads"| DEM
+        DDO -->|"update"| DDM
+        DSD -->|"reads"| DDM
+    end
+
+    BEM -.->|"shallow copy - 22 of 28 tag entries<br/>and 21 of 29 type entries are the SAME objects"| CEM
+    CEM -.->|"shallow copy - 27 of 28 tag entries<br/>and 28 of 29 type entries are the SAME objects"| DEM
+    BDM -.->|"shallow copy - 22 of 26 tag entries<br/>and ALL 28 type entries are the SAME objects"| CDM
+    CDM -.->|"shallow copy - 23 of 26 tag entries<br/>and ALL 28 type entries are the SAME objects"| DDM
+
+    classDef override fill:#fff2cc,stroke:#b8860b,stroke-width:3px,color:#000
+    classDef maps fill:#dae8fc,stroke:#3c6ea5,stroke-width:2px,color:#000
+    classDef passthru fill:#f0f0f0,stroke:#999999,stroke-width:1px,stroke-dasharray:5 4,color:#000
+
+    class BEI,BSE,BSD,CEO,CSE,CDO,DEO,DSE,DDO,DSD override
+    class BDI override
+    class BEM,BDM,CEM,CDM,DEM,DDM maps
+    class CSD,CDA passthru
+```
+
+The dotted copy edges carry the measured counts. The CER encoder keeps 22 of
+28 tag entries and 21 of 29 type entries as the same objects as BER's; the DER
+encoder keeps 27 of 28 and 28 of 29 relative to CER; on the decoder side the
+copies keep 22 of 26 and then 23 of 26 tag entries, with all 28 type entries
+identical at both steps. The derived decoder `TYPE_MAP`s are therefore
+100 percent inherited, so CER and DER strictness applies only on the schemaless
+tag-driven path; [Registration and import
+order](#registration-and-import-order) traces the mechanism.
+
+### Sharing by identity
+
+The import chain is linear. CER imports BER
+(`from pyasn1.codec.ber import encoder` at the top of `cer/encoder.py`,
+`from pyasn1.codec.ber import decoder` at the top of `cer/decoder.py`), and
+DER imports CER through the matching
+`from pyasn1.codec.cer import ...` imports atop `der/encoder.py` and
+`der/decoder.py`. Each derived module builds its dispatch tables at import with
+a shallow `dict.copy()` plus a targeted `update()`: the module-level
+`TAG_MAP = encoder.TAG_MAP.copy()` / `TAG_MAP.update({...})` blocks and their
+`TYPE_MAP` counterparts in `cer/encoder.py` and `der/encoder.py`, and the same
+`decoder.TAG_MAP.copy()` / `decoder.TYPE_MAP.copy()` pattern in
+`cer/decoder.py` and `der/decoder.py`.
+
+Python's `dict.copy()` is shallow: it duplicates the mapping, not the values,
+so every entry the derived codec does not overwrite points at the very same
+object BER constructed once. A port must make the same choice explicitly,
+because every propagation rule in this chapter follows from whether derived
+tables alias the base codec's entries or duplicate them.
+
+Measured by identity comparison:
+
+| map | size | objects identical to BER | genuinely distinct |
+| --- | --- | --- | --- |
+| `der.encoder.TAG_MAP` | 28 | 22 | 6 |
+| `der.encoder.TYPE_MAP` | 29 | 21 | 8 |
+| `der.decoder.TAG_MAP` | 26 | 22 | 4 |
+| `der.decoder.TYPE_MAP` | 28 | 28 | 0 |
+
+The distinct entries are few. On the encoder side they are Boolean, Real, the
+two time types, Set/SetOf, Sequence/SequenceOf (`TYPE_MAP` only: CER's
+`omitEmptyOptionals` and `ifNotEmpty` rewrites in `cer/encoder.py`) and the
+stray integer key; on the decoder side,
+Boolean (from CER), BitString and OctetString (the two
+`supportConstructedForm = False` subclasses in `der/decoder.py`), plus a
+re-instantiated but behaviorally identical `RealPayloadDecoder`: the
+`RealPayloadDecoder = decoder.RealPayloadDecoder` alias in `der/decoder.py`,
+whose `# TODO: prohibit non-canonical encoding` comment marks it as a
+placeholder for a stricter decoder nobody wrote. Between CER and DER the
+coupling is tighter still: DER's entire encoder-side contribution is one class
+plus two class attributes.
+
+Editing a BER payload codec thus edits DER, and there is no indirection
+to absorb the change. An edit to `IntegerEncoder.encodeValue` in
+`ber/encoder.py` changes the bytes DER produces for every certificate and
+signature input in the ecosystem; DER has no Integer implementation of its own
+to fall back on.
+
+Setting an attribute on a shared instance reconfigures all three codecs at
+once:
+
+```python
+# probe: three codecs, one object
+be.encode(univ.Integer(0))                      # b'\x02\x01\x00'
+be.TYPE_MAP[univ.Integer.typeId].supportCompactZero = True
+de.encode(univ.Integer(0))                      # b'\x02\x00'  <-- DER changed
+be.TYPE_MAP[univ.Integer.typeId] is de.TYPE_MAP[univ.Integer.typeId]   # True
+```
+
+One assignment meant to tune BER made DER emit a zero-length INTEGER: invalid
+DER that no conforming verifier round-trips. To vary behavior, subclass the
+encoder, build a fresh map, and pass it to `Encoder(tagMap=..., typeMap=...)`,
+whose `__init__` in `ber/encoder.py` forwards both maps into the
+`SingleItemEncoder` it constructs; never set attributes on module-level
+instances. Because any behavioral edit under `pyasn1/codec/ber/` propagates to
+`der.encode`/`der.decode` by object identity, a change validated only against
+`tests/codec/ber/` can alter DER output and defeat signature verification
+downstream while every BER test passes; `tests/codec/der/` is the only guard,
+and it does not cover every payload type.
+
+### Registration and import order
+
+Because the derived maps are copied at import time, what matters for
+registering a new type is when the registration happens, not where it is
+written. Source-level registration in the BER modules is enough: an entry
+added to `ber/encoder.py` or `ber/decoder.py` at module level is in place
+before CER's module body runs, so CER's copy picks it up and DER's copy of CER
+follows. Add entries to `cer/` or `der/` only when that codec needs different
+behavior, and never key a derived `TAG_MAP` by `univ.Sequence.tagSet` or
+`univ.Set.tagSet`, which equal the SequenceOf/SetOf tagSets and overwrite the
+inherited entries; the aliasing is worked through at the end of this section.
+
+Runtime mutation after import does not propagate. Inserting into
+`ber.encoder.TYPE_MAP` from application code leaves `cer.encode`/`der.encode`
+raising `No encoder for ...` because the copies were already taken. A
+downstream package registering types at runtime must do so per codec.
+
+The decoder modules each run a `typeId` backfill loop that copies tag-keyed
+decoders into the type-keyed map: the module-level
+`for typeDecoder in TAG_MAP.values():` loop under the
+`# Put in non-ambiguous types for faster codec lookup` comment in
+`ber/decoder.py`, `cer/decoder.py` and `der/decoder.py`, guarded by
+`typeId not in TYPE_MAP`. The type-keyed map exists because several
+constructed types are ambiguous or untagged by tagSet alone ([The type
+system](#the-type-system)), and both maps read each type's `typeId` at import
+([Type identity and dispatch keys](#type-identity-and-dispatch-keys)). By the
+time CER's loop runs, its `TYPE_MAP` is already a copy of BER's post-backfill
+map, so the derived loops add nothing, and `cer.decoder.TYPE_MAP` and
+`der.decoder.TYPE_MAP` share all 28 entries with BER's. The encoder side has
+no backfill at all: encoder `TYPE_MAP`s are written out longhand (the
+module-level `TYPE_MAP = {...}` literal in `ber/encoder.py`) or copied and
+updated by hand.
+
+The two maps serve different code paths, and the schema-driven path bypasses
+derived-codec strictness. Both paths live in `SingleItemDecoder.__call__` in
+`ber/decoder.py`: schemaless decoding dispatches through `tagMap` in the
+`stGetValueDecoderByTag` state, while decoding with an `asn1Spec` (the way
+X.509 and LDAP consumers actually call pyasn1) takes the
+`stGetValueDecoderByAsn1Spec` state, which consults
+`typeMap[chosenSpec.typeId]` first, and the `TYPE_MAP` hit returns BER's
+permissive decoder. Two probes confirm it:
+
+- `der.decode(b'\x24\x06\x04\x01a\x04\x01b')` raises
+  `Constructed encoding form prohibited`, but the same bytes with
+  `asn1Spec=univ.OctetString()` decode fine.
+- `cer.decode(b'\x01\x01\x01')` raises `Unexpected Boolean payload: 1`, but
+  with `asn1Spec=univ.Boolean()` returns `True`.
+
+The one DER restriction that always applies is `supportIndefLength = False`,
+because it sits on `der/decoder.py`'s `SingleItemDecoder` itself rather than
+in a map. Removing the `typeId not in TYPE_MAP` guard from the derived
+backfill loops looks like a cleanup but would newly route schema-driven
+CER/DER decodes through the strict subclasses, breaking every caller that
+currently (if accidentally) relies on DER accepting constructed OCTET STRINGs
+under a schema.
+
+Registration history has also left dead weight in the maps. The module-level
+`TAG_MAP.update({...})` block in `cer/encoder.py` registers
+`univ.Sequence.typeId: SequenceEncoder()`, an integer key (12) in a map
+otherwise keyed by `TagSet`. The entry is unreachable: `TAG_MAP` is consulted
+in one place only, the `self._tagMap[baseTagSet]` fallback in
+`SingleItemEncoder.__call__` in `ber/encoder.py`, where the key is always a
+`TagSet`. DER inherits the dead entry through the copy.
+
+Deleting the entry is safe and changes nothing observable. "Repairing" it into
+a `univ.Sequence.tagSet: SequenceEncoder()` key is not safe:
+`univ.Sequence.tagSet == univ.SequenceOf.tagSet` (both UNIVERSAL 16
+constructed), so the repaired key would overwrite the inherited `SequenceOf`
+entry and reroute tag-driven SEQUENCE OF encoding in CER and DER through
+`SequenceEncoder`, a different encoder with a different contract, and no
+current test covers that path, so the regression would ship. The same tagSet
+aliasing is already in use once, on purpose: the `TAG_MAP.update({...})` block
+in `der/encoder.py` registers `univ.Set.tagSet: SetEncoder()`, which replaces
+CER's `SetOf` entry, harmless today only because `SingleItemEncoder.__call__`
+consults `TYPE_MAP` first, through its `self._typeMap[typeId]` lookup.
+
+A second scrap sits nearby. CER's SET sort key,
+`SetEncoder._componentSortKey` in `cer/encoder.py`, re-tests
+`if asn1Spec.tagSet:` inside a branch its outer guard has already excluded,
+so the inner `return asn1Spec.tagSet` is unreachable; DER's rewrite dropped
+the dead test.
+
+### What each dialect changes
+
+The framing switch is two class attributes on `SingleItemEncoder`. BER
+declares `fixedDefLengthMode = None` and `fixedChunkSize = None` at the top of
+the class body in `ber/encoder.py` ("honor the caller"), and
+`SingleItemEncoder.__call__` applies whichever is not `None` by overwriting
+`defMode`/`maxChunkSize` in the options dict. CER's subclass sets
+`fixedDefLengthMode = False` and `fixedChunkSize = 1000`; DER's sets
+`fixedDefLengthMode = True` and `fixedChunkSize = 0`. Those two-line class
+bodies are the whole definite-vs-indefinite and chunked-vs-unchunked
+distinction, so flipping either attribute changes every byte of that codec's
+output and fails nearly all of its encoder tests. On the decoder side, each
+dialect re-declares the decoder class chain through the class-attribute seams
+described in [The decoder stack](#the-decoder-stack).
+
+The CER encoder overrides, all in `cer/encoder.py`: `BooleanEncoder` emits
+`255` for true (X.690 11.1); `RealEncoder` forces the value's own base;
+`TimeEncoderMixIn` canonicalizes times, UTC `Z` only, no comma separator,
+trailing zeros stripped, length windows enforced through its
+`MIN_LENGTH`/`MAX_LENGTH` class bounds; `SequenceEncoder` flips
+`omitEmptyOptionals` to `True`. `SetOfEncoder` sorts serialized components
+right-padded with `\x00`. `SetEncoder` sorts SET components with a static
+`_componentSortKey` that keys an untagged CHOICE on
+`componentType.minTagSet`, ignoring which alternative is populated. That is
+not a shortcut: X.690 9.3 orders an untagged CHOICE by the smallest tag among
+its (nested) alternatives, which is exactly this sort.
+
+DER's encoder contribution is a single class. `SetEncoder` replaces CER's
+static sort key with a dynamic `_componentSortKey` that resolves the actual
+chosen alternative, the ordering X.690 10.3 (read with X.680 8.6) requires of
+DER. The difference is observable (structure from
+`SetWithAlternatingChoiceEncoderTestCase` in
+`tests/codec/der/test_encoder.py`, a SET of Integer plus an untagged Choice of
+OctetString/Boolean): with the OctetString alternative chosen, DER emits
+INTEGER first while CER emits the CHOICE first, since CER keys on the smallest
+possible tag (Boolean's 1) regardless of the value present. Both outputs are
+what X.690 requires, one per rule set.
+
+The two sort keys look like duplication but must not be collapsed in either
+direction. Replacing DER's dynamic key with CER's static one fails the
+`testComponentsOrdering` cases of `SetWithAlternatingChoiceEncoderTestCase`
+and makes DER SET ordering depend on the schema rather than the value, which
+invalidates signatures over any SET containing an untagged CHOICE while
+raising no error. Pointing CER at DER's dynamic key breaks CER conformance
+with X.690 9.3, which fixes an untagged CHOICE's position by its smallest
+alternative tag before any value is chosen.
+
+The CER decoder adds one class, `BooleanPayloadDecoder`, accepting only
+`0x00`/`0xFF`; its BitString/OctetString/Real entries are aliases of the BER
+classes, re-instantiated but identical. The DER decoder adds two one-line
+subclasses, `BitStringPayloadDecoder` and `OctetStringPayloadDecoder`, setting
+`supportConstructedForm = False` (enforced by the
+`if not self.supportConstructedForm:` checks in the parent classes'
+`valueDecoder` methods in `ber/decoder.py`), plus
+`supportIndefLength = False` on its `SingleItemDecoder`; how that one
+attribute shuts indefinite framing off entirely is covered in [Two framing
+modes](#two-framing-modes).
+
+### Configuration surfaces
+
+The encoder is configured at construction: `Encoder.__init__(tagMap, typeMap,
+**options)` builds a `SingleItemEncoder` eagerly, and `ber.encoder.encode` is
+a real configured instance, the `encode = Encoder()` assignment at the bottom
+of `ber/encoder.py`. That constructor is also the supported route for custom
+maps ([Sharing by identity](#sharing-by-identity)). The decoder is not
+construction-configured: `Decoder.__call__` is a classmethod, callable on the
+class with no instance ever created, and the class has no `__init__`, so
+`Decoder(tagMap=...)` raises `TypeError: Decoder() takes no arguments`. To
+customize decoding, go through `StreamingDecoder` or `SingleItemDecoder`.
+
+Both families accept unknown options without complaint.
+`SingleItemEncoder.__init__` in `ber/encoder.py` and
+`SingleItemDecoder.__init__` in `ber/decoder.py` end in `**ignored`, so a
+misspelled option constructs and runs as if it had never been passed, and
+nothing warns. `Encoder(tagmap={}, typemap={}, bogusOption=42)` constructs and
+encodes normally, the lowercase misspellings having done nothing, while the
+correctly spelled empty maps raise `No encoder for ...`. Call-time options
+behave the same way: `encode(seq, defmode=False)` returns definite-length
+output because the lookup in `AbstractItemEncoder.encode` is
+`options.get('defMode', True)`. When debugging "my option had no effect",
+check spelling before logic; the `DeprecationWarning` shims warn only for the
+module attributes `tagMap`/`typeMap`, not for keyword arguments.
+
+Tightening `**ignored` into strict validation is a breaking change:
+`StreamingDecoder.__init__` in `ber/decoder.py` forwards its whole
+`**options`, including per-call keys like `substrateFun`, into the
+`SingleItemDecoder` constructor, and that pass-through works only because the
+constructor discards what it does not recognize.
+
+### The options channel
+
+The encoder's `options` dict is rebuilt by `**` expansion at each call
+boundary, so mutations never escape upward; within a component loop it is
+mutated in place, and the mutation propagates downward into every later
+`encodeFun(...)` call. Three sites mutate it:
+
+1. `SequenceEncoder.encodeValue` in `ber/encoder.py` runs
+   `options.update(ifNotEmpty=namedType.isOptional)` per component when
+   `omitEmptyOptionals` is on. The flag is consumed by the
+   `options.get('ifNotEmpty', False)` check in `AbstractItemEncoder.encode`,
+   where a constructed encoder that produced empty substrate emits nothing at
+   all.
+2. `SetEncoder.encodeValue` in `cer/encoder.py` does the same, but iterating
+   in sorted order, so the flag in effect for a component is determined by tag
+   order; a component with no `namedType` inherits the previous component's
+   flag.
+3. `TimeEncoderMixIn.encodeValue` in `cer/encoder.py` runs
+   `options.update(maxChunkSize=1000)` unconditionally, even under DER where
+   `fixedChunkSize = 0` just set unlimited; the mutation is inert only
+   because the length windows cap time strings far below 1000.
+
+Two sites avoid mutation because their key must reach a bounded audience: the
+open-type wrapper in `SequenceEncoder.encodeValue` builds a copy,
+`dict(options, wrapType=...)`, so the key reaches exactly one child; and
+`SequenceOfEncoder._encodeComponents` does a destructive read,
+`options.pop('wrapType', None)`, so only the outermost SEQUENCE OF applies
+the wrapper. Changing that `pop` to a `get`, or hoisting it out of
+`_encodeComponents`, double-wraps nested open types and breaks
+`SequenceEncoderWithUntaggedSetOfOpenTypesTestCase` in
+`tests/codec/cer/test_encoder.py` and `tests/codec/der/test_encoder.py`.
+
+Because options are an untyped dict, `ifNotEmpty` leaks into the public
+surface: `ber.encode(seq, ifNotEmpty=True)` on a SEQUENCE that encodes to
+empty returns `b''` outright. `NestedOptionalSequenceEncoderTestCase` in
+`tests/codec/cer/test_encoder.py` pins the nesting behavior across seven
+optional/defaulted arrangements.
+
+### Encoding as a pure function
+
+An encoder is a pure function of the value it is given, enforced by
+construction since commit `ca9ec2e` (PR #112), and the shape of the code is
+the point. The hazard sits in the type system: `getComponentByPosition`
+defaults to `instantiate=True`, and in
+`SequenceAndSetBase.getComponentByPosition` (`pyasn1/type/univ.py`) an absent
+component is created and stored as a side effect of being read:
+
+```python
+# pyasn1/type/univ.py, SequenceAndSetBase.getComponentByPosition
+if componentValue is noValue:
+    self.setComponentByPosition(idx)   # <-- mutates the caller's object
+```
+
+`Sequence.values()` routes through exactly that path, and until the fix three
+encoder loops iterated the value directly, so merely encoding a record
+materialized every absent OPTIONAL and DEFAULT component in it, and callers
+inspecting the record afterwards saw phantom fields. The fix landed in BER's
+`SequenceEncoder`, CER's `SetEncoder` and the native codec, with DER
+inheriting CER's:
+
+```python
+# pyasn1/codec/ber/encoder.py, SequenceEncoder.encodeValue (the post-fix form)
+for idx in range(value._componentTypeLen or len(value._dynamicNames)):
+    component = value.getComponentByPosition(idx, instantiate=False)
+    if namedTypes:
+        namedType = namedTypes[idx]
+        if component is univ.noValue and (
+                namedType.isOptional or namedType.isDefaulted):
+            continue                       # absent and omissible: emit nothing
+        elif component is univ.noValue:
+            component = namedType.asn1Object   # absent and mandatory: borrow schema
+```
+
+Iterating `range(...)` avoids the instantiating property; `instantiate=False`
+makes the read non-destructive (that path of
+`SequenceAndSetBase.getComponentByPosition` returns `noValue` both for
+genuinely absent components and for present-but-schema-only ones, so the
+single `is univ.noValue` test covers both); and the `elif` borrows the
+schema's prototype instead of storing anything back. The cross-codec
+regression test, `tests/codec/test_encoder_no_mutation.py`, snapshots
+component state with `instantiate=False` before and after encoding through all
+five entry points; its design is described in [TESTING.md](TESTING.md), and
+its inventory entry sits under [Encoder guards](#encoder-guards).
+
+The families part ways on defaults, and the divergence is intentional: the
+native encoder renders them, the BER family omits them. `SetEncoder.encode` in
+`native/encoder.py` substitutes `namedType.asn1Object` for an absent
+defaulted component, while `SequenceEncoder.encodeValue` in `ber/encoder.py`
+skips any component equal to its default. Both are correct, since DER must
+not transmit a value equal to its default while a Python dict is more useful
+with the effective value filled in.
+
+Reverting any encoder loop to `value.values()` / `.items()` reintroduces the
+mutation and fails the snapshot assertions in
+`tests/codec/test_encoder_no_mutation.py`, plus
+`DefaultedSequenceEncoderNoMutationTestCase` in
+`tests/codec/der/test_encoder.py` and `DefaultedSetEncoderNoMutationTestCase`
+in `tests/codec/cer/test_encoder.py`. Without the `elif` branch, an absent
+mandatory component reaches the encoder as `noValue` and the encode dies
+with `Attempted "typeId" operation on ASN.1 schema object`. Purity
+governs how the encoders read the value; how they read the schema is a
+separate contract with its own reason not to change, described in [Recursive
+schemas](#recursive-schemas).
+
+### The native codec
+
+`codec/native/` converts between pyasn1 objects and Python built-ins. It
+borrows the `TAG_MAP`/`TYPE_MAP`/`Encoder` naming but derives from nothing:
+its maps are written from scratch, with no copy and no backfill, so a type
+registered for the BER family is never visible to `native`.
+
+The shape differs at four points. There is no substrate and no framing: the
+native `AbstractItemEncoder.encode` returns a Python object, not the
+`(substrate, isConstructed, isOctets)` triple. The native encoder never
+consults an `asn1Spec`, while the native decoder requires one, enforced by
+the `isinstance(asn1Spec, base.Asn1Item)` check at the top of
+`SingleItemDecoder.__call__` in `native/decoder.py`. `native.decoder.decode`
+returns a bare object, not `(value, remainder)`; the Sphinx doc-comment on
+its `decode` attribute shows the tuple-unpacking form, which would raise. And `ChoiceEncoder` in
+`native/encoder.py` fully overrides `encode` to iterate `value.items()`,
+because `Choice.items()` yields at most the one chosen alternative and
+index-based iteration would be wrong.
+
+The module-level `encode` is a `SingleItemEncoder`, not an `Encoder`, per the
+`encode = SingleItemEncoder()` assignment at the bottom of
+`native/encoder.py`. Its `__call__` has no `asn1Spec` parameter, so
+`native.encoder.encode(value, asn1Spec=X)` swallows the argument into
+`**options` and behaves exactly as if it were absent. Subclassing
+`native.encoder.Encoder` (whose `__call__` does accept `asn1Spec`) changes
+nothing about the module-level `encode`; you must instantiate your subclass
+yourself.
+
+Switching `native/encoder.py`'s module-level assignment to
+`encode = Encoder()` alters the recursion signature for every custom encoder
+registered in `native.encoder.TYPE_MAP`. A subclass "fixed" via
+`Encoder.SINGLE_ITEM_ENCODER` while the assignment stands produces no
+observable effect: the debugging that follows is time spent on a path the
+module-level `encode` never takes.
+
+## The decoder pipeline
+
+The stream is the third act, where the translation meets input that may
+arrive a piece at a time. The BER decoder is a stack of three thin objects
+on top of a generator
+pipeline: every value decoder, and the per-item driver itself, is a Python
+generator, and the only thing that travels back up the pipeline besides a
+finished object is a `SubstrateUnderrunError` used as a "not enough bytes yet,
+ask again" sentinel. A Python generator is a function whose frame suspends at
+each `yield` and resumes in place with all local state intact; a port needs
+coroutines, continuations, or an explicit state object that can park a
+half-finished parse and re-enter it. Every strange-looking idiom in
+`ber/decoder.py` (loops whose variable is used after the loop, explicit state
+integers, a nesting counter inside a kwargs dict) falls out of that one
+choice.
+
+The diagram follows one TLV through the pipeline, from substrate
+normalization through the state machine to the final `yield`; the sections
+below walk the same path from the outside in.
+
+```mermaid
+flowchart TD
+    IN["substrate in"] --> AS{"asSeekableStream"}
+    AS -->|"bytes bytearray memoryview OctetString"| B1["new io.BytesIO"]
+    AS -->|"already io.BytesIO"| B2["identity passthrough"]
+    AS -->|"seekable true"| B3["passthrough unwrapped"]
+    AS -->|"seekable false"| B4["CachingStreamWrapper<br/>cache dropped past DEFAULT_BUFFER_SIZE<br/>seeks before markedPosition undefined"]
+    AS -->|"no seekable attr"| B5["UnsupportedSubstrateError"]
+
+    B1 --> L1
+    B2 --> L1
+    B3 --> L1
+    B4 --> L1
+
+    L1["Layer 1 Decoder.__call__<br/>classmethod, no constructor args<br/>returns first item plus tail"]
+    L2["Layer 2 StreamingDecoder.__iter__<br/>one top level item per pass"]
+    L3["Layer 3 SingleItemDecoder.__call__<br/>generator, is also decodeFun"]
+    L1 --> L2 --> L3
+
+    L3 --> DEPTH{"_nestingLevel greater than MAX_NESTING_DEPTH"}
+    DEPTH -->|"yes"| EDEPTH["PyAsn1Error nesting depth<br/>CVE-2026-30922"]
+    DEPTH -->|"no"| BUMP["options _nestingLevel plus 1<br/>pop allowEoo"]
+
+    BUMP --> EOOG{"allowEoo and supportIndefLength"}
+    EOOG -->|"gate off, DER sets supportIndefLength false"| MARK
+    EOOG -->|"on, read 2 octets"| EOOC{"octets equal EOO_SENTINEL"}
+    EOOC -->|"yes"| EOOY["yield eoo.endOfOctets singleton<br/>compared with is"]
+    EOOC -->|"no, seek back 2"| MARK
+
+    MARK["markedPosition equals tell<br/>start of this TLV"] --> T
+
+    T["stDecodeTag<br/>MAX_TAG_OCTETS on long form<br/>CVE-2026-59884"]
+    T --> LEN
+    LEN["stDecodeLength<br/>MAX_LENGTH_OCTETS on long-form octet count<br/>length greater than sys.maxsize guard"]
+    LEN -->|"length is -1 and not supportIndefLength"| EIND["PyAsn1Error indefinite not supported"]
+    LEN --> GVD{"stGetValueDecoder<br/>asn1Spec is None"}
+
+    GVD -->|"yes"| BYTAG["stGetValueDecoderByTag<br/>TAG_MAP tagSet then tagSet 0"]
+    GVD -->|"no"| BYSPEC["stGetValueDecoderByAsn1Spec<br/>TYPE_MAP by typeId then TAG_MAP by base tag"]
+
+    BYTAG -->|"hit"| DV
+    BYTAG -->|"miss"| TRYEX
+    BYSPEC -->|"hit"| DV
+    BYSPEC -->|"miss"| TRYEX
+
+    TRYEX{"stTryAsExplicitTag<br/>constructed and non universal"}
+    TRYEX -->|"yes, rawPayloadDecoder"| LOOPBACK
+    TRYEX -->|"no, defaultErrorState"| ERRSEL{"defaultErrorState"}
+    ERRSEL -->|"stErrorCondition, default"| ERAISE["PyAsn1Error not in asn1Spec"]
+    ERRSEL -->|"stDumpRawValue, opt in subclass"| DUMP["defaultRawDecoder AnyPayloadDecoder"]
+    DUMP --> LOOPBACK
+    LOOPBACK["extra while loop trip<br/>stDecodeTag skipped"] --> DV
+
+    DV{"stDecodeValue<br/>length is -1"}
+    DV -->|"yes"| IND["indefLenValueDecoder<br/>terminates on endOfOctets"]
+    DV -->|"no"| DEF["valueDecoder"]
+
+    DEF --> EXACT{"bytesRead equals length"}
+    EXACT -->|"no and no substrateFun"| EEXACT["PyAsn1Error read N instead of M<br/>raised in parent frame"]
+    EXACT -->|"substrateFun, under read allowed"| STOP
+    EXACT -->|"yes"| STOP
+    IND --> STOP
+    STOP["stStop, yield value"] --> L2
+
+    DEF --> ANY["AnyPayloadDecoder untagged<br/>seek to markedPosition<br/>length plus header bytes"]
+    ANY --> DEF
+
+    DEF -.->|"decodeFun with double star options<br/>forwards _nestingLevel"| L3
+    IND -.->|"decodeFun with allowEoo true"| L3
+    DEF -.->|"open type re decode on fresh BytesIO<br/>decodeOpenTypes"| L3
+
+    RFS["readFromStream"]
+    DEF -. "short or None read" .-> RFS
+    T -. "short or None read" .-> RFS
+    LEN -. "short or None read" .-> RFS
+    RFS -. "yield SubstrateUnderrunError sentinel" .-> L2
+    L2 -. "caller feeds more bytes, next resumes in place" .-> RFS
+    RFS -. "empty read raises EndOfStreamError, not resumable" .-> ERAISE2["EndOfStreamError"]
+```
+
+### Normalizing input to a seekable stream
+
+Every entry point funnels its substrate through `asSeekableStream`
+(`streaming.py`), which has four outcomes. An `io.BytesIO` passes through as
+the same object. Bytes-likes and `univ.OctetString` are copied into a fresh
+`BytesIO`. Any other already-seekable object, an open binary file or a gzip
+member, also passes through unwrapped. Only a stream reporting
+`seekable() == False` is wrapped in `CachingStreamWrapper`, and an object
+with no `seekable` attribute raises `UnsupportedSubstrateError`. Because the
+passthroughs hand the caller's object to the pipeline unchanged, dropping
+them breaks `RestartableDecoderTestCase.testPartialReadingFromNonBlockingStream`
+(`tests/codec/ber/test_decoder.py`), whose `BytesIO` subclass must reach
+`readFromStream` intact.
+
+Seekability is load-bearing: `readFromStream` seeks back after short reads,
+the end-of-octets probe in `SingleItemDecoder.__call__` pushes back two
+octets, and the untagged-`ANY` path (`AnyPayloadDecoder.valueDecoder`)
+rewinds to the start of the current TLV. `CachingStreamWrapper` fakes
+seekability by teeing reads into an internal cache, and it forgets history
+when told to: the decoder assigns `substrate.markedPosition` at the start of
+each item, and once the cache exceeds `io.DEFAULT_BUFFER_SIZE` the
+`markedPosition` setter discards consumed data and renumbers the stream so
+`tell()` restarts at 0. On a wrapped stream, positions saved across an item
+boundary are not stale, they are invalid: the coordinate system shifted
+underneath them. Code that stashes `tell()` across items passes every
+`bytes`-based test and reads garbage on wrapped streams. The cache-drop
+threshold is an interpreter constant (131072 on CPython 3.14), not a pyasn1
+one. Lowering it breaks the constructed decoders' position arithmetic (the
+`while substrate.tell() - original_position < length` loops in
+`ConstructedPayloadDecoderBase.valueDecoder`); forced to 0, a SEQUENCE
+containing an `ANY` fails with `Excessive components decoded`. Raising it
+grows peak memory for long-lived non-seekable streams, and nothing reports
+the growth.
+
+The passthrough design has two further edges. `markedPosition` is set as an
+ordinary attribute, so an exotic file-like whose class fixes its attribute
+set with `__slots__` fails at the `substrate.markedPosition` assignment in
+`SingleItemDecoder.__call__` before any decoding. The legacy 3-argument
+`substrateFun` adapter (the `substrateFunWrapper` closure in
+`Decoder.__call__`) asserts `isinstance(substrate, io.BytesIO)`, an
+invariant that holds only for bytes-like inputs, so an open file plus a
+0.4-style callback raises `AssertionError` today; the adapter itself is
+inventoried in the
+[compatibility surface](#compatibility-surface-looks-dead-is-not).
+
+### The decoder stack
+
+`SingleItemDecoder` (`decoder.py`) decodes one TLV and is the state machine.
+Its `__call__` is a generator, and it is also the `decodeFun` handed to every
+payload decoder, which is how recursion happens. `StreamingDecoder` owns the
+normalized stream and yields one top-level object per pass. `Decoder` is the
+one-shot facade: its `__call__` is a classmethod, it returns after the first
+top-level object, and trailing data comes back as `tail`, not as an error.
+Giving `Decoder` an `__init__` while `__call__` stays a classmethod would not
+disturb `decode(substrate)` — a classmethod binds the class no matter what —
+but it would turn the class-call form `Decoder(substrate)` into a silent
+constructor that swallows the substrate as an `__init__` argument, where
+today it fails loudly with `TypeError: Decoder() takes no arguments`, and any
+per-instance state it stored would be invisible to the classmethod
+`__call__`. The reason the decoder takes no constructor arguments at all is
+covered under [Configuration surfaces](#configuration-surfaces).
+
+Customization comes in two flavors that do not interchange. Per call:
+`tagMap`/`typeMap` kwargs flow into `SingleItemDecoder.__init__` (with
+`_MISSING` distinguishing "not supplied" from `None`), and they also travel
+down the pipeline inside `options`, visible to user callbacks. Per subclass:
+the `SINGLE_ITEM_DECODER` / `STREAMING_DECODER` class attributes (on
+`StreamingDecoder` and `Decoder` respectively) are the seams CER and DER
+use, re-declaring the three-class chain with different maps
+(`cer/decoder.py`, `der/decoder.py`). What varies within one decode is an
+option; what defines a dialect is a class attribute.
+`ErrorOnDecodingTestCase.testRawDump` (`tests/codec/ber/test_decoder.py`) is
+the worked example of the subclass route. The seams are also what let DER
+disable indefinite lengths at all; without them the `testIndefMode` cases of
+`BitStringDecoderTestCase` and `OctetStringDecoderTestCase` in
+`tests/codec/der/test_decoder.py` fail.
+
+### The per-item state machine
+
+Ten module-level state integers (`stDecodeTag` through `stStop`, declared in
+one tuple unpacking above `SingleItemDecoder` in `decoder.py`) drive a
+`while state is not stStop` loop whose body is a sequence of plain `if`
+blocks in source order. A transition to a later block falls through in the
+same pass; a transition to an earlier block costs another `while` trip, on
+which `stDecodeTag` is skipped so tag and length are not re-read.
+
+In execution order:
+
+- `stDecodeTag` reads the identifier octet; long-form tags (`tagId == 0x1F`)
+  accumulate seven bits per octet under `MAX_TAG_OCTETS` (value and origin
+  in [Decoder limits](#decoder-limits)). Short tags are memoized per first
+  octet; long tags are not, because their key space is unbounded. The
+  `tagSet = lastTag + tagSet` statement prepends to an already-populated
+  `tagSet`: that is how nested EXPLICIT tags build up.
+- `stDecodeLength` handles short, long and indefinite (`length = -1`) forms;
+  both length limits fire here ([Decoder limits](#decoder-limits)).
+- `stGetValueDecoder` is a two-way switch: no `asn1Spec` means tag-driven,
+  otherwise spec-driven. The block comment right after this `if` explains
+  why both exist: IMPLICIT tagging destroys base-type information, so the
+  substrate alone is not always sufficient.
+- `stGetValueDecoderByTag` does a `TAG_MAP` lookup on the full `tagSet`,
+  retried on `tagSet[:1]`. A hit goes to `stDecodeValue`, a miss to
+  `stTryAsExplicitTag`.
+- `stGetValueDecoderByAsn1Spec` resolves the spec (a `TagMap` is
+  subscripted; a concrete type matches on `tagSet` or `tagMap`), then maps
+  it to a payload decoder through `TYPE_MAP[typeId]` with a `TAG_MAP`
+  fallback on the base tag set (grep `baseTagSet`) so tagged subtypes
+  recover their base codec. This is the schema-driven half of the two-tier
+  dispatch described under [The type system](#the-type-system); a `KeyError`
+  from that fallback is normal control flow, since `TYPE_MAP` is not
+  exhaustive ([Type identity and dispatch
+  keys](#type-identity-and-dispatch-keys)), and the `KeyError` caught around
+  the `asn1Spec[tagSet]` subscript is the only kind of miss the decoder
+  tolerates ([Tag dispatch: tagSet and
+  TagMap](#tag-dispatch-tagset-and-tagmap)).
+- `stDecodeValue` runs the payload decoder; the `length == -1` test picks
+  the definite or indefinite branch; the block also hosts the
+  `recursiveFlag=False` compatibility shim. Constructed payload decoders
+  work on an `asn1Spec.clone()` and read `componentType` from the clone,
+  never from the spec ([Recursive schemas](#recursive-schemas)).
+- `stTryAsExplicitTag`: if the unmatched tag is constructed and
+  non-universal, assume an EXPLICIT wrapper and install `rawPayloadDecoder`,
+  which calls `decodeFun` again with the accumulated `tagSet`
+  (`RawPayloadDecoder.valueDecoder`). Otherwise fall to `defaultErrorState`.
+- `stDumpRawValue` is the opt-in lenient mode (substitutes an
+  `AnyPayloadDecoder`), reachable only when a subclass sets
+  `defaultErrorState = stDumpRawValue`.
+- `stErrorCondition` is the default error state; it raises `PyAsn1Error`
+  naming the tag set and spec.
+
+`stStop` is never tested by an `if`; `stDecodeValue` sets it and breaks, and
+the single `yield value` at the end of `__call__` delivers the result.
+
+Reordering the `if` blocks only changes how many `while` trips a transition
+costs; swapping `stTryAsExplicitTag` above `stDecodeValue` in a scratch copy
+left all 1,261 tests passing. Treat the order as a performance detail with
+nothing to gain from touching it. Hard-coding a raise in place of
+`defaultErrorState`, by contrast, removes the only supported way to build a
+lenient decoder.
+
+### Suspend and resume
+
+`readFromStream` (`streaming.py`) is a generator with three outcomes per
+`read(size)`:
+
+- `None` (non-blocking stream, nothing ready): yields a
+  `SubstrateUnderrunError` and loops.
+- empty (stream finished): raises `EndOfStreamError`, which is
+  unrecoverable. It subclasses `SubstrateUnderrunError` (`pyasn1/error.py`),
+  so `except SubstrateUnderrunError` catches both, but only the yielded form
+  can resume.
+- short read: seeks back by what it read, then yields a sentinel.
+
+Its yield sequence is therefore zero or more sentinels followed by exactly
+one payload, payload always last. Every caller is written accordingly:
+
+```python
+# CORRECT: the shape used in pyasn1/codec/ber/decoder.py, IntegerPayloadDecoder.valueDecoder
+for chunk in readFromStream(substrate, length, options):
+    if isinstance(chunk, SubstrateUnderrunError):
+        yield chunk
+
+# the loop variable outlives the loop and now holds the bytes
+if chunk:
+    value = int.from_bytes(bytes(chunk), 'big', signed=True)
+```
+
+The leaked loop variable is the return-value protocol; re-yielding the
+sentinel suspends the whole generator chain so the application can add data
+and resume. The natural rewrite is wrong:
+
+```python
+# WRONG: reads like a simplification, and kills resumability
+chunk = next(readFromStream(substrate, length, options))
+value = int.from_bytes(bytes(chunk), 'big', signed=True)
+```
+
+On buffered `bytes` this passes every test (the first yield is the data). On
+partial input the first yield is a sentinel, so `bytes(chunk)` raises; the
+sentinel never reached the caller, so the caller was never given the chance
+to supply more data. A comprehension that filters sentinels is equally
+wrong: it drains the generator internally, turning a resumable decoder into
+a busy loop. The one legitimate `next()` is `Decoder.__call__`'s
+trailing-data read (`tail = next(readFromStream(substrate))`), safe only
+because `size=-1` can never trigger the short-read branch; even there, a
+non-blocking `read(-1)` returning `None` would hand a sentinel back as
+`tail`.
+
+The second half of the contract: `SingleItemDecoder.__call__` and every
+`valueDecoder`/`indefLenValueDecoder` are generators. In Python, `return`
+inside a generator ends iteration without producing a value; only `yield`
+delivers one, so a port that models decoders as ordinary functions must add
+an explicit "more input needed" channel in place of the suspended frame.
+Changing a `yield value` into `return value` does not raise: `return` just
+stops iteration, so the caller's loop variable holds whatever was yielded
+last, a sentinel, a stale component, or nothing, producing a `NameError` or
+a wrong object with no error raised. Early `return` is only safe after the
+result has been yielded (the pattern in `RawPayloadDecoder.valueDecoder`,
+`BitStringPayloadDecoder.valueDecoder` and
+`OctetStringPayloadDecoder.valueDecoder`).
+
+`RestartableDecoderTestCase.testPartialReadingFromNonBlockingStream`
+(`tests/codec/ber/test_decoder.py`) is the executable specification: a
+`BytesIO` subclass returning `None` on alternate reads must produce exactly
+eight sentinel yields before the finished object, with the partial object
+reachable via `error.context['asn1Object']`. Resumption has a real
+limitation: it works only for substrates left unwrapped, because
+`CachingStreamWrapper.read`
+feeds `None` straight into its cache and dies with a `TypeError`, so
+non-blocking input is supported for seekable substrates only. Any refactor
+of the idiom into `next()`, a comprehension, or a helper that returns
+instead of yielding breaks the restartable-decoder test and, for users
+driving pyasn1 off a socket, converts partial-input handling into a
+`TypeError` or an infinite loop while the full-buffer suite stays green.
+
+### Length accounting
+
+For definite-length values, `stDecodeValue` records the position before
+invoking the payload decoder and afterwards checks that exactly `length`
+bytes were consumed. No payload decoder is trusted to police its own extent.
+With a user `substrateFun`, reading less is legal (the point of partial
+decoding), so only over-reads are rejected; for indefinite lengths the check
+is skipped entirely, since the extent is defined by end-of-octets.
+
+The cost is diagnostic distance: the check runs in the parent frame after
+the child generator is gone, so `"Read N bytes instead of expected M."`
+names neither component nor offset, and container loops
+(`while substrate.tell() - original_position < length`, in
+`ConstructedPayloadDecoderBase.valueDecoder`) stop early when a child
+over-consumed. When debugging exact-length failures, enable the decoder
+debug log ([The debug hook](#the-debug-hook)) and read the last successful
+codec choice rather than staring at the raising frame.
+
+A loosened check would let malformed nested encodings decode into
+structurally valid but wrong objects, the classic BER-parsing differential
+that signature verification depends on not happening. Symmetry in the
+`substrateFun` case breaks exactly one test:
+`NonStreamingCompatibilityTestCase.testPartialDecodeWithDefaultSubstrateFun`
+(`tests/codec/ber/test_decoder.py`), whose synthesized callback is written
+to read zero bytes of a 14-byte value.
+
+### Two framing modes
+
+Indefinite length is `length = -1` internally (set in `stDecodeLength`) and
+routes to `indefLenValueDecoder` instead of `valueDecoder`, so every
+constructed payload decoder has two nearly parallel implementations
+(`ConstructedPayloadDecoderBase.valueDecoder` versus its
+`indefLenValueDecoder`) differing mainly in loop termination: byte count
+versus end-of-octets test. Chunked and constructed-form string decoding in
+both modes also leans on `Tag` equality ignoring `tagFormat`
+([Deriving types: clone and subtype](#deriving-types-clone-and-subtype)).
+
+The terminator is a singleton: `eoo.endOfOctets` (`eoo.py`), cached in
+`EndOfOctets.__new__`, and compared with `is`, never `==`, at all of its
+comparison sites in `decoder.py` (currently 16: grep `is eoo.endOfOctets`).
+`is` is Python's object-identity operator, the same discipline the `noValue`
+sentinel relies on ([The value sentinel](#the-value-sentinel)), and the
+invariant a port must reproduce is identity of one sentinel object, not
+value equality. Identity matters because `EndOfOctets` derives from
+`SimpleAsn1Type` with `defaultValue = 0`, so `==` against a decoded
+zero-valued `Integer` could be true: replacing the `is` comparisons with
+`==` makes such an `Integer(0)` terminate an indefinite container early,
+truncating the parse with no error.
+`EndOfOctetsTestCase.testExpectedEoo` pins the identity
+(`tests/codec/ber/test_decoder.py`). The `TagMap` negative entry that keeps
+end-of-octets visible to the enclosing loop even inside an `ANY` is
+described under [Tag dispatch: tagSet and
+TagMap](#tag-dispatch-tagset-and-tagmap).
+
+Detection sits at the top of `SingleItemDecoder.__call__` behind two
+independent gates (`if allowEoo and self.supportIndefLength`). `allowEoo` is
+a per-call option popped from `options` so it never leaks to nested calls;
+containers re-supply it explicitly, so a bare `00 00` at top level errors
+while the same bytes inside an indefinite container terminate it.
+`supportIndefLength` is a class attribute, and DER turns the whole feature
+off with that one attribute (`supportIndefLength = False` on its
+`SingleItemDecoder` in `der/decoder.py`): the gate means DER never even
+consumes the two probe octets, and the
+`length == -1 and not self.supportIndefLength` guard in `stDecodeLength`
+rejects a `0x80` length outright. Moving the `supportIndefLength` test out
+of the gate makes DER consume two octets it must not; re-enabling it on DER
+defeats the `testIndefMode` cases of `BitStringDecoderTestCase` and
+`OctetStringDecoderTestCase` in `tests/codec/der/test_decoder.py`. CER keeps
+indefinite-length support enabled; CER requires indefinite-length framing
+for long strings. DER's remaining decoder overrides are inventoried under
+[What each dialect changes](#what-each-dialect-changes), and this attribute
+is the one DER restriction that applies on every decode path
+([Registration and import order](#registration-and-import-order)).
+
+### Deferred typing: ANY and open types
+
+An `ANY` value is the complete encoding, header included, but by the time
+the decoder knows the component is `ANY`, it has already consumed the tag
+and length. So it rewinds: each item starts with
+`substrate.markedPosition = substrate.tell()` (in
+`SingleItemDecoder.__call__`, after the end-of-octets probe, before
+`stDecodeTag`), and the untagged-`ANY` path (the `isUntagged` branch of
+`AnyPayloadDecoder.valueDecoder`) seeks back to it while enlarging `length`
+by exactly the header bytes it rewound past. That balanced arithmetic is
+what keeps the exact-length check satisfied: change either side and you
+must change both. How an untagged `Any` comes to match any TLV at all is a
+property of its `tagMap` ([Tag dispatch: tagSet and
+TagMap](#tag-dispatch-tagset-and-tagmap)).
+`AnyDecoderTestCase.testByUntagged` (`tests/codec/ber/test_decoder.py`) pins
+the rewind: decoding `04 03 66 6f 78` against `univ.Any()` yields
+`Any('\x04\x03fox')`, header and all. Changing
+`length += currentPosition - fullPosition` without the matching seek breaks
+`testByUntagged` and the implicitly- and explicitly-tagged open-type
+families (`SequenceDecoderWithImplicitlyTaggedOpenTypesTestCase`,
+`SequenceDecoderWithExplicitlyTaggedOpenTypesTestCase` and their `SetOf`
+variants, `tests/codec/ber/test_decoder.py`). Moving the `markedPosition`
+assignment before the end-of-octets probe is position-neutral, because the
+probe restores the position either way, but it must stay before
+`stDecodeTag`.
+
+Open types are the schema layer above `ANY`: a container with `hasOpenTypes`
+decodes normally first, leaving the open component as raw octets, then,
+under `openTypes=...` or `decodeOpenTypes=True`, resolves the real type from
+the governing component and re-decodes on a fresh `BytesIO` built from the
+component's octets (the `asSeekableStream(...asOctets())` calls in
+`ConstructedPayloadDecoderBase.valueDecoder` and `indefLenValueDecoder`).
+The fresh stream gives the payload its own position space; `**options` still
+crosses that boundary, so the nesting counter keeps counting. Resolution
+failure is non-fatal: logged and skipped, raw octets left in place (the
+inner `except KeyError` around the `namedType.openType[governingValue]`
+lookup).
+
+### Bounding nesting depth
+
+Counting stack frames cannot bound this decoder: the "recursion" is a chain
+of suspended generator frames, so Python's own `RecursionError` fires at a
+depth that depends on which payload decoders are in the chain. The
+mitigation for CVE-2026-30922 carries its own counter, inside the options
+dict (the limit's value and inventory row are under
+[Decoder limits](#decoder-limits)):
+
+```python
+# pyasn1/codec/ber/decoder.py, SingleItemDecoder.__call__ entry
+_nestingLevel = options.get('_nestingLevel', 0)
+
+if _nestingLevel > MAX_NESTING_DEPTH:
+    raise error.PyAsn1Error(
+        'ASN.1 structure nesting depth exceeds limit (%d)' % MAX_NESTING_DEPTH
+    )
+
+options['_nestingLevel'] = _nestingLevel + 1
+```
+
+`**kwargs` semantics make this correct: splatting builds a fresh dict per
+call, as under [The class spine](#the-class-spine), so each
+`SingleItemDecoder.__call__` gets its own dict and the increment is local to
+that invocation and its descendants. Siblings each see the parent's value
+(`NestingDepthLimitTestCase.testSiblingsDontIncreaseDepth`,
+`tests/codec/ber/test_decoder.py`), and the counter resets per top-level
+item because `StreamingDecoder.__iter__` never passes the key.
+
+The maintenance rule: the counter survives only because every `decodeFun`
+call site forwards the existing options. A call written without `**options`
+restarts the count at zero for everything below it, and nothing fails: no
+test, no warning, no change on well-formed input. The mitigation just stops
+applying to that subtree, and no existing test detects the loss
+(`NestingDepthLimitTestCase.testNoRecursionError` in
+`tests/codec/ber/test_decoder.py` exercises only the plain constructed
+path). All 20 `decodeFun` call sites in `ber/decoder.py` forward the dict,
+either as `**options` or as `**dict(options, allowEoo=True)` (which
+preserves the key). The open-type re-entries (the
+`decodeFun(stream, asn1Spec=openType, ...)` calls in
+`ConstructedPayloadDecoderBase.valueDecoder` and `indefLenValueDecoder`)
+matter most: they cross into a brand-new stream
+([Deferred typing: ANY and open types](#deferred-typing-any-and-open-types))
+and look the most natural to "clean up".
+
+`options` is simultaneously the nesting counter, the `context` attached to
+`SubstrateUnderrunError`, the `asn1Object` back-reference carrier
+(`AbstractPayloadDecoder._passAsn1Object`), the `allowEoo` channel and the
+user-option pass-through. Adding a key is cheap; removing or renaming one is
+not. A stack-frame count in place of the counter re-introduces
+`RecursionError` and breaks `testWithSchema` in the same class and the
+`NestingDepthLimitTestCase` mirrors in `tests/codec/cer/test_decoder.py`
+and `tests/codec/der/test_decoder.py`.
+
+## Security hardening inventory
+
+The build order ends with the stream; what remains is inventory, and the
+attack record comes first. Every entry in it exists because of a shipped
+vulnerability or regression. The decoder limits face
+attacker-controlled input directly: each bounds a quantity that a few crafted
+bytes could otherwise grow into unbounded CPU or memory use.
+
+### Decoder limits
+
+All five limits live in `pyasn1/codec/ber/decoder.py`, where the named
+constants sit at the top of the module (file locations in the
+[module map](#module-map)), and are inherited unchanged by CER and DER
+through the `SingleItemDecoder` subclasses in `cer/decoder.py` and
+`der/decoder.py`. The values are tunable policy, not protocol facts. The tag
+and length rows fire inside the per-item state machine's `stDecodeTag` and
+`stDecodeLength` handling ([The per-item state
+machine](#the-per-item-state-machine)); the nesting counter travels in the
+options dict ([Bounding nesting depth](#bounding-nesting-depth)). The related
+type-layer bound, the CVE-2026-59886 conversion guard on `Real`, lives in the
+type system rather than the decoder; its mechanism is described in
+[Bounded conversion of Real](#bounded-conversion-of-real).
+
+| Limit | Value | Enforced in | Attack it stops | Origin |
+| --- | --- | --- | --- | --- |
+| `MAX_OID_ARC_CONTINUATION_OCTETS` | 20 continuation octets (arcs up to 147 bits, 21 octets in all) | `ObjectIdentifierPayloadDecoder.valueDecoder` (OID) and `RelativeOIDPayloadDecoder.valueDecoder` (RELATIVE-OID), in the continuation loop before the arc accumulates | A short run of continuation octets accumulates a single arc into an unbounded integer | CVE-2026-23490 / GHSA-63vm-454h-vhhq, 0.6.2, commit `be353d7`, `CHANGES.rst` under `Revision 0.6.2` |
+| `MAX_TAG_OCTETS` | 20 octets (140-bit tag IDs) | the long-form tag loop in `SingleItemDecoder.__call__`'s `stDecodeTag` block | Unbounded long-form tag IDs build a huge integer from a tiny substrate; a companion fix in `tag.py` stopped `repr()` tripping the Python 3.11+ int-to-str limit | CVE-2026-59884 / GHSA-m4p7-r5rc-7g4j, 0.6.4, commit `516db4e`, `CHANGES.rst` under `Revision 0.6.4` |
+| `MAX_NESTING_DEPTH` | 100 levels | `SingleItemDecoder.__call__`, at generator entry | Deeply nested encodings (`b'\x30\x80' * 50000` is two bytes per level) drive the generator chain into `RecursionError` | CVE-2026-30922 / GHSA-jr27-m4p2-rc6r, 0.6.3, commit `25ad481`, `CHANGES.rst` under `Revision 0.6.3` |
+| `MAX_LENGTH_OCTETS` | 8 octets | the `stDecodeLength` block of `SingleItemDecoder.__call__`, before any length octet is read | An oversized length header produced an `OverflowError` escaping as a non-`PyAsn1Error` | No CVE; issue #54 / PR #100, 0.6.3, commit `6d40bde`, `CHANGES.rst` under `Revision 0.6.3` |
+| `length > sys.maxsize` guard | platform-dependent | inline in the `stDecodeLength` block, after length accumulation; no named constant | An 8-octet length can still encode 2^64-1, which no `read()` can satisfy | No CVE; PR #108, commit `100f3af`, `CHANGES.rst` under the pending `Revision 0.7.0`; on `main` before the 0.6.4 release-prep commit, but absent from the shipped `v0.6.4` tag lineage |
+| *Supplementary:* OID arcs accumulate in a list | not numeric | `ObjectIdentifierPayloadDecoder.valueDecoder` / `RelativeOIDPayloadDecoder.valueDecoder`: `list.append` per arc, one `tuple()` at the final yield | The previous `oid += (subId,)` was quadratic in arc count | CVE-2026-59885 / GHSA-8ppf-4f7h-5ppj, 0.6.4, commit `5932cc8`, `CHANGES.rst` under `Revision 0.6.4` |
+
+The checks fire before the value they guard is materialized: the tag limit
+before the shift, the length-octet limit before the octets are read, the OID
+limit before the arc accumulates. Moving a check after its accumulation keeps
+the error message and loses the protection.
+
+The boundary tests come in matched pairs, at-limit passes and one-over fails,
+so an off-by-one in a comparison is caught. All live in
+`tests/codec/ber/test_decoder.py`:
+`ObjectIdentifierDecoderTestCase.testMaxAllowedContinuationOctets` vs
+`testOneOverContinuationLimit` (OID),
+`LargeTagDecoderTestCase.testVeryLongTagRoundTrip` vs `testExcessiveLongTag`
+(tags), `LengthFieldLimitTestCase.testMaxAllowedLengthFieldWorks` vs
+`testOversizedLengthField` (length), and
+`LengthFieldLimitTestCase.testLengthValueAtPlatformLimitIsNotRejected` vs
+`testLengthValueAbovePlatformLimitIsRejected` (the `sys.maxsize` guard,
+reachable via a monkey-patched `decoder.sys.maxsize`).
+
+The at-limit tests also pin the exact values, so lowering the OID or tag
+limits breaks `testMaxAllowedContinuationOctets` and
+`testVeryLongTagRoundTrip`. Dropping the OID limit below 18 would go further
+and start rejecting real-world UUID-based OIDs, since a UUID arc
+(`2.25.<uuid>`, ITU-T X.667) is 128 bits, 19 octets of which 18 are
+continuation octets. Raising `MAX_NESTING_DEPTH` past what the generator
+chain sustains converts a clean `PyAsn1Error` back into `RecursionError`
+(`testNoRecursionError`'s closing `except RecursionError` arm in
+`tests/codec/ber/test_decoder.py` pins the distinction). Reverting the OID
+accumulator to tuple concatenation reintroduces CVE-2026-59885 with no test
+failure: the fix changed complexity, not results.
+
+### Encoder guards
+
+Every CVE through 0.6.4 is a decoder or type-system issue; what the encoders
+carry is structural bounds checks plus one regression fix, all cheap to
+delete by accident. Removing any of these bounds converts a `PyAsn1Error`
+into malformed output written to the wire, because the encoder has no
+downstream validator. The Baseline column names the commit that introduced
+each guard.
+
+| Guard | Location | What it prevents | Baseline |
+| --- | --- | --- | --- |
+| Length-octet count cap | `AbstractItemEncoder.encodeLength` (`ber/encoder.py`) | Emitting a long-form length needing >126 octets, a corrupt header instead of an exception | `598be09`, 2007 |
+| Negative OID arc rejection | `ObjectIdentifierEncoder.encodeValue` (`ber/encoder.py`) | A negative arc falling through the base-128 packer and emitting no octets at all rather than raising | `daa77af`, 2013 |
+| Negative RELATIVE-OID arc rejection | `RelativeOIDEncoder.encodeValue` (`ber/encoder.py`) | The same hazard on the separate RELATIVE-OID path | `d17e0e1`, 2024 |
+| Impossible first/second arc rejection | the two `Impossible first/second arcs` raise sites in `ObjectIdentifierEncoder.encodeValue` (`ber/encoder.py`) | OIDs whose first two arcs cannot pack into the combined first octet | `8d34914`, 2017 |
+| REAL scale-factor bound | `RealEncoder.encodeValue` (`ber/encoder.py`, grep `# bug if raised`) | Guards the 2-bit scale field; the `# bug if raised` comment marks it an internal assertion, not input validation | `44bdb82`, 2013 |
+| REAL exponent-length bound | `RealEncoder.encodeValue` (`ber/encoder.py`, grep `Real exponent overflow`) | Caps the exponent at 255 octets; distinct from the CVE-2026-59886 type-layer fix in `Real.__float__` (`univ.py`), a separate fix in a separate module ([Bounded conversion of Real](#bounded-conversion-of-real)) | `ae6f36f`, 2011 |
+| CER/DER time length window | `TimeEncoderMixIn.encodeValue` (`cer/encoder.py`), with `MIN_LENGTH`/`MAX_LENGTH` overridden per type on `GeneralizedTimeEncoder` and `UTCTimeEncoder` | Enforces canonical time length ([What each dialect changes](#what-each-dialect-changes)) and also caps what the forced `maxChunkSize=1000` could chunk | `7c5db32`, 2017; `dd6640a`, 2019 |
+| Inconsistency guard | `SequenceEncoder.encodeValue` (`ber/encoder.py`), `SetEncoder.encodeValue` (`cer/encoder.py`), `SetEncoder.encode` (`native/encoder.py`) | Rejects constrained containers violating their `subtypeSpec`; a narrow check, see the caveats below | `66afc89`, 2019 (raise reworked into `PyAsn1Error` by `7a599a1`, 2024) |
+| Encoder purity | the `getComponentByPosition(idx, instantiate=False)` component loops in the same three methods | `encode()` materializing absent DEFAULT/OPTIONAL components in the caller's object ([Encoding as a pure function](#encoding-as-a-pure-function)) | `ca9ec2e` / PR #112, 0.7.0-dev |
+| Purity regression test | `tests/codec/test_encoder_no_mutation.py` | Pins the purity guard across all five encoder entry points | 0.7.0-dev |
+
+The `isInconsistent` guard returns `False` immediately when the object has no
+`subtypeSpec` (`SequenceAndSetBase.isInconsistent`, `univ.py`), which is the
+common case, so a SEQUENCE missing a mandatory component passes the guard and
+fails later, deep in a leaf encoder. Do not treat it as schema validation;
+constructed types defer all validation to this one read, as described in
+[The class spine](#the-class-spine). The REAL guards predate CVE-2026-59886
+by over a decade. Anyone touching `RealEncoder._chooseEncBase` or
+`_dropFloatingPoint` (`ber/encoder.py`) should remember that CER overrides
+`_chooseEncBase` and DER inherits the CER instance, so a base-class change
+reaches all three codecs. Reverting the purity fix restores an input-mutation
+bug that survived unnoticed from 0.5.x to 0.6.4.
+
+## Compatibility surface: looks dead, is not
+
+The graph and the translation also carry a second inventory: API kept alive
+for the ecosystem alone. Everything in this section reads as dead code and is
+actually the frozen surface that `pyasn1-modules`, `pysnmp` and a long tail
+of private schema packages compile against. Almost nothing has an in-repo
+caller. Unlike the codec
+layer's deprecated module attributes, none of it emits a
+`DeprecationWarning`, so deleting any of it is a breaking change with no
+migration signal: removal raises `AttributeError` at import time in
+downstream schema modules, and this repo's suite stays green while
+`pyasn1-modules` and `pysnmp` fail to load. Decline tidy-up PRs that remove
+these.
+
+- **Getter shims on `Asn1Type`** (`base.py`): `getTagSet()`,
+  `getEffectiveTagSet()`, `getTagMap()`, `getSubtypeSpec()`, `hasValue()`.
+- **Class aliases** (`base.py`): `Asn1ItemBase = Asn1Type`,
+  `AbstractSimpleAsn1Item = SimpleAsn1Type`,
+  `AbstractConstructedAsn1Item = ConstructedAsn1Type`. Bare assignments keep
+  one class under two names, so `isinstance` written against either name
+  still matches; that interchangeability is the compatibility promise.
+- **`sizeSpec` machinery** (`base.py`): `ConstructedAsn1Type.sizeSpec`,
+  `_moveSizeSpec`, `verifySizeSpec()`. `_moveSizeSpec` has inverted branches:
+  with an existing `subtypeSpec` present, its `if subtypeSpec:` branch
+  replaces it with the `sizeSpec` (`subtypeSpec = sizeSpec`) instead of
+  accumulating, so passing both drops the former and nothing reports the
+  loss.
+- **`TagMap` legacy accessors** (`tagmap.py`): `getPosMap()`, `getNegMap()`,
+  `getDef()`.
+- **Assorted shims**: `TagSet.getBaseTag()` (`tag.py`);
+  `NamedType.getName()`/`getType()` (`namedtype.py`);
+  `NamedValues.getName()`/`getValue()`/`getValues()` (`namedval.py`);
+  `Integer.getNamedValues()` (`univ.py`);
+  `ConstructedAsn1Type.setDefaultComponents()`/`getComponentType()`
+  (`base.py`); `Sequence.getComponentTagMapNearPosition()`/
+  `getComponentPositionNearType()` and `Set.getComponent()` (`univ.py`);
+  `Real.isPlusInfinity()`/`isMinusInfinity()`/`isInfinity()` (`univ.py`).
+- **Codec-layer shims**: the deprecated `tagMap`/`typeMap` module attributes,
+  the 3-argument `substrateFun` adapter (`substrateFunWrapper` inside
+  `Decoder.__call__`, `decoder.py`), and the `recursiveFlag=False` shim in
+  `SingleItemDecoder.__call__` (`decoder.py`). The narrow scope of those
+  deprecation warnings is covered in
+  [Configuration surfaces](#configuration-surfaces); the adapter's input
+  assumption in [Normalizing input to a seekable
+  stream](#normalizing-input-to-a-seekable-stream).
+
+`NamedType.getName()` is not dead even internally: `Choice` calls it from
+`__contains__`, `__iter__`, `keys()` and `items()` (`univ.py`) to implement
+its dict protocol. `Choice.getMinTagSet()` (`univ.py`) is broken: it forwards
+to `self.minTagSet`, which no constructed type defines (`minTagSet` lives on
+`NamedTypes`), so it raises `AttributeError` for every input. The working
+spelling is `componentType.minTagSet`, as the CER encoder's
+`SetEncoder._componentSortKey` does (`cer/encoder.py`). Fixing
+`Choice.getMinTagSet` to return `self.componentType.minTagSet` is the one
+safe repair in this section, since the current implementation cannot succeed
+for any input.
+
+## Known warts (intentional)
+
+The last inventory collects the defects the graph, the translation and the
+stream keep on purpose. Several are genuine bugs, but each is either
+depended upon or not worth the compatibility cost. Do not fix any of
+them as a drive-by; each needs its own dedicated change with tests.
+
+- **Two `ValueConstraintError` classes.** Violations raise the
+  `pyasn1.type.error` one; `except pyasn1.error.ValueConstraintError` never
+  fires; the docstrings name the wrong class. Only `except PyAsn1Error`
+  catches both. Details in
+  [The constraint algebra](#the-constraint-algebra).
+- **`isSuperTypeOf`'s missing parentheses.** `matchTags=False`
+  short-circuits the whole check to `True`. Observable only to external
+  callers leaving `verifyConstraints` at its default; the decoder folds both
+  flags to `False`, where both readings agree. A narrow API break, not a
+  repo-wide decode change. Details in
+  [Type relations and their flags](#type-relations-and-their-flags).
+- **`subtype()` accumulates every keyword**, not just constraints:
+  `univ.OctetString('abc').subtype(encoding='utf-8').encoding` is
+  `'iso-8859-1utf-8'`. Use `clone()` for non-constraint attributes. Details
+  in [Deriving types: clone and subtype](#deriving-types-clone-and-subtype).
+- **The dead integer key in CER's encoder `TAG_MAP`**: unreachable,
+  inherited by DER; safe to delete, unsafe to repair. Details in
+  [Registration and import order](#registration-and-import-order).
+- **DER's encoder `TAG_MAP` loses CER's `SetOfEncoder`** because
+  `univ.Set.tagSet == univ.SetOf.tagSet`. Harmless only because `TYPE_MAP` is
+  consulted first. Details in
+  [Registration and import order](#registration-and-import-order).
+- **`SequenceOf`/`SetOf` positional arguments are unsafe.** The constructor
+  loop in `SequenceOfAndSetOfBase.__init__` (`univ.py`) writes a literal
+  `'componentType'` key instead of the loop variable, so
+  `SequenceOf(Integer(), someTagSet)` assigns the `TagSet` to `componentType`
+  and drops the tag set. Use keyword arguments.
+- **`Choice.__iter__` raises `StopIteration` inside a generator**
+  (`univ.py`). PEP 479 replaces a `StopIteration` escaping a generator body
+  with `RuntimeError` rather than ending the iteration, so
+  `list(univ.Choice())` on an unset Choice raises instead of yielding
+  nothing; a port should end iteration over an unset Choice by returning,
+  not by raising.
+- **`Choice.getMinTagSet()` is broken**: it raises `AttributeError` for
+  every input. See the
+  [compatibility surface](#compatibility-surface-looks-dead-is-not) above.
+- **`_moveSizeSpec` has inverted branches**: passing both `subtypeSpec` and
+  `sizeSpec` drops the former. See the
+  [compatibility surface](#compatibility-surface-looks-dead-is-not) above.
+- **Unknown keyword arguments are swallowed everywhere.** `Asn1Type.__init__`
+  freezes arbitrary keywords into `readOnly`, and `clone()`/`subtype()`
+  round-trips depend on that; the codec constructors end in `**ignored`, so
+  `decode(b'\x02\x01\x01', typoOption=True)` succeeds. The encoder-side
+  probe is in [Configuration surfaces](#configuration-surfaces).
+- **Derived-codec strictness is bypassed under a schema.** The derived
+  decoder `TYPE_MAP`s are fully inherited and consulted before `TAG_MAP`
+  when an `asn1Spec` is supplied, so DER's `supportConstructedForm=False`
+  and CER's canonical-Boolean check are inert on the schema path; only DER's
+  `supportIndefLength=False` always applies. Details in
+  [The codec family](#the-codec-family) and
+  [Registration and import order](#registration-and-import-order).
+- **`native.decoder.decode` returns a bare object**, not
+  `(value, remainder)`, and the Sphinx doc-comment on its `decode` attribute
+  shows the tuple-unpacking form, which would raise. Details in
+  [The native codec](#the-native-codec).
+- **`CHANGES.rst` mixes Markdown link syntax into reST.** Roughly three
+  dozen Markdown-style `[pr #N](url)` / `[issue #N](url)` links render as
+  literal text. Not worth a churn-heavy rewrite mid-release; if ever fixed,
+  do it as a dedicated pass verified with `tox -e docs`, since the file is
+  compiled into the `-W` build.
+

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,284 @@
+# pyasn1 testing guide
+
+How this suite is built, and what a new test must look like to fit it. The
+conventions here are not stylistic preferences; several of them are the
+difference between a test that runs in CI and one that silently never executes.
+
+This file lives at `docs/TESTING.md`, deliberately outside the Sphinx source
+tree (`docs/source/`). See the placement note in
+[ARCHITECTURE.md](ARCHITECTURE.md) for why.
+
+Code and tests are cited by symbol: file plus test class, method or `tox.ini`
+section, never line numbers. Line numbers rot with every edit, and this guide
+serves human readers as much as agents. If a change renames a cited symbol or
+alters a convention described here, update this file in the same commit. If a
+cited symbol is missing, the code has moved or changed; re-verify the claim
+rather than deleting the reference.
+
+## Running the suite
+
+Use the form CI uses:
+
+```bash
+python -Werror -m unittest discover -s tests
+```
+
+The `-Werror` is the important part, and it lives only on the `commands` line
+of `[testenv]` in `tox.ini`, not in any GitHub Actions workflow. Running plain
+`python -m unittest discover -s tests` will pass locally on changes that fail
+CI, because every warning raised during a test is an error under the real gate.
+The most common way to trip this is touching a deprecated module attribute
+(`decoder.tagMap` / `encoder.typeMap`), which raises `DeprecationWarning`; use
+`TAG_MAP` / `TYPE_MAP` instead.
+
+A single module, for quick iteration:
+
+```bash
+python -m unittest tests.type.test_univ
+```
+
+There is also a hand-registered aggregate runner, `python -m tests`, discussed
+under [suite registration](#suite-registration-the-silent-failure) below. It
+and `discover` should always report the same test count; both currently report
+1261 tests. A divergence means a module is missing from a `__main__.py` list.
+
+### The gates, and which Python version runs each
+
+Everything is driven by `tox.ini`; the workflow just installs tox and
+`tox-gh-actions` and calls `python -m tox`.
+
+| Env | Command | Gate |
+|-----|---------|------|
+| `py38`…`py314`, `pypy38`…`pypy310` | `{envpython} -Werror -m unittest discover -s tests` (`[testenv]`) | any warning fails |
+| `cover` | `coverage run --source pyasn1 -m unittest discover` then `coverage report --fail-under 80` (`[testenv:cover]`) | coverage ≥ 80% |
+| `bandit` | `bandit -r pyasn1 -c .bandit.yml` (`[testenv:bandit]`) | scans `pyasn1/` only, never `tests/` |
+| `docs` | `make -C docs html SPHINXOPTS="-W --keep-going"` (`[testenv:docs]`) | any Sphinx warning fails |
+| `build` | `python -m build` + `twine check --strict` on both artifacts (`[testenv:build]`) | README must render |
+
+Two traps hide in that table.
+
+The `cover` env is not the same run as the `py3xx` envs. It omits `-Werror`
+and it omits `-s tests`, so discovery starts from the repository root rather
+than `tests/` (the `[testenv:cover]` command). A green `tox -e cover`
+therefore does not prove the `-Werror` gate passes.
+
+The `[gh-actions]` mapping in `tox.ini` pins the non-test envs to single
+matrix legs: `docs` runs only under Python 3.9, and `cover`, `build` and
+`bandit` only under Python 3.10. Removing or renaming a matrix entry in
+`.github/workflows/main.yml` silently drops the corresponding gate; CI stays
+green while no longer checking coverage, security or documentation.
+
+`tox` itself is not installed in a fresh checkout. Install it before relying
+on any row above, and never report a gate as passing that you did not run.
+
+## Anatomy of a test module
+
+Every test module follows the same skeleton. Copy it exactly.
+
+```python
+#
+# This file is part of pyasn1 software.
+#
+# Copyright (c) 2026, Simon Pichugin <simon.pichugin@gmail.com>
+# License: https://pyasn1.readthedocs.io/en/latest/license.html
+#
+import sys
+import unittest
+
+from tests.base import BaseTestCase
+
+from pyasn1.type import univ
+
+
+class SomethingTestCase(BaseTestCase):
+
+    def setUp(self):
+        BaseTestCase.setUp(self)
+        # per-test fixtures here
+
+    def testThing(self):
+        assert univ.Integer(1) == 1
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)
+```
+
+**The copyright header.** Existing files carry the Ilya Etingof attribution
+verbatim (2005-2020, or 2005-2019 in `tests/codec/test_streaming.py`); leave
+those alone. A genuinely new module gets the same
+six-line block with a new attribution line, as the header block of
+`tests/codec/test_encoder_no_mutation.py` does.
+
+**`BaseTestCase` is mandatory.** It installs a null debug logger in `setUp`
+and clears it in `tearDown` (`tests/base.py`). The consequence is worth
+internalizing: the whole suite — bar `NonStreamingCompatibilityTestCase` in
+`tests/codec/ber/test_decoder.py`, whose `setUp` deliberately undoes the
+logger — runs with pyasn1's debug logging *enabled* and its output discarded,
+so every `if LOG:` branch in the codecs actually executes, and a malformed
+logging format string is a test failure rather than dead code. If you override `setUp`, you must call `BaseTestCase.setUp(self)`
+first, or you leak logger state into the rest of the suite.
+
+**Import style varies by file, not by directory.** Copy the spelling used by
+the exact module you are editing. Only three modules use the module-import
+form (`tests/test_debug.py`, `tests/codec/ber/test_decoder.py` and
+`tests/type/test_tag.py`), writing `from pyasn1 import error` and then
+`error.PyAsn1Error`. Everything else, *including the sibling
+`tests/codec/ber/test_encoder.py`*, uses `from pyasn1.error import
+PyAsn1Error` and the bare name. A single security fix has been written both
+ways in the same commit because it touched files on both sides of that split.
+Imports are one `from … import …` per line; the lone comma-joined exception
+is the paired Unicode-error import in `tests/type/test_univ.py`.
+
+### Suite registration: the silent failure
+
+`unittest discover` finds any `test_*.py`. The aggregate runner
+`python -m tests` does not; it loads a hand-maintained list of module names.
+Each package has a `__main__.py` whose `suite` list enumerates its children:
+
+- the `suite` list in `tests/__main__.py` → `test_debug`, `tests.type`, `tests.codec`
+- the `suite` list in `tests/codec/__main__.py` → the two cross-codec modules plus the four codec packages
+- the `suite` list in `tests/codec/ber/__main__.py` → `test_encoder`, `test_decoder`
+
+**Adding a new test module means editing the parent `__main__.py` too.** When
+`tests/codec/test_encoder_no_mutation.py` was added in commit `ca9ec2e`, the
+commit also had to add `'tests.codec.test_encoder_no_mutation.suite'` to
+`tests/codec/__main__.py`. Skip that step and the module is invisible to
+`python -m tests` while still passing under `discover`: the failure mode is
+silence, not an error.
+
+## Assertion idioms
+
+This suite uses bare `assert` statements and almost nothing else. It currently
+holds about 1,600 bare asserts against a handful of `self.assertIs` calls,
+zero `assertRaises`, and no pytest anywhere. Match that. An `assertRaises`
+block would be stylistically foreign to every other file.
+
+Negative cases use the try/except/else idiom, with the message naming what was
+wrongly accepted:
+
+```python
+try:
+    decoder.decode(malicious_payload)
+except error.PyAsn1Error:
+    pass
+else:
+    assert 0, 'Excessive continuation octets tolerated'
+```
+
+Older modules write `assert 0, '…'`; newer code writes `assert False, '…'`
+(`ObjectIdentifierDecoderTestCase.testExcessiveContinuationOctets` and
+`LengthFieldLimitTestCase.testOversizedLengthField`, respectively, both in
+`tests/codec/ber/test_decoder.py`). Either is fine; the `else:` clause is the
+part that matters, because a bare `except: pass` without it would pass even
+when nothing raised.
+
+When a specific exception type must be distinguished, add an explicit branch
+rather than a broader catch. The length-limit tests assert that a
+`PyAsn1Error` arrives and specifically that an `OverflowError` does not:
+
+```python
+except error.PyAsn1Error:
+    pass
+except OverflowError:
+    assert False, 'Got OverflowError instead of PyAsn1Error'
+```
+
+Constraint violations raise `pyasn1.type.error.ValueConstraintError`, which is
+a *different class* from `pyasn1.error.ValueConstraintError` and not an
+instance of it. Catching `PyAsn1Error` works for both; catching
+`pyasn1.error.ValueConstraintError` catches no constraint violation at all.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for why both exist.
+
+## Testing a security fix
+
+A hardening change *should* ship the five-part test set below. Existing
+coverage is uneven and no single limit currently ships all five parts, so
+combine the strongest examples rather than copying any one of them. The
+nesting-depth limit has parts 1, 4 and 5 (`NestingDepthLimitTestCase` in
+`tests/codec/ber/test_decoder.py`, with same-named mirrors in
+`tests/codec/cer/test_decoder.py` and `tests/codec/der/test_decoder.py`),
+but its under- and over-limit tests sit at depths 50 and 200 against a limit
+of 100, not at the exact boundary parts 2 and 3 require.
+`LengthFieldLimitTestCase` (`tests/codec/ber/test_decoder.py`) shows parts
+1-4 with exact 8- and 9-octet boundaries, including the message assertion in
+`testLengthValueAbovePlatformLimitIsRejected`, but has no mirrors. The OID
+continuation-octet tests in `ObjectIdentifierDecoderTestCase` (same file)
+predate the template and show parts 1-3 with exact 20- and 21-octet
+boundaries, inside a type-named rather than limit-named class.
+
+The five parts:
+
+1. **The malicious input is rejected.** Construct the substrate by hand as a
+   `bytes` literal with a comment explaining the encoding, and assert
+   `PyAsn1Error` via the try/except/else idiom.
+2. **Input exactly at the limit still decodes.** This is what proves the limit
+   did not break legitimate data.
+3. **One over the limit is rejected.** The explicit boundary case.
+4. **The error message carries the limit.** Assert on message content, e.g.
+   `assert 'maximum readable size' in str(exc).lower()`, so the diagnostic
+   stays useful. Check the actual wording in the raise site rather than
+   guessing.
+5. **Mirror the rejection tests into `tests/codec/cer/test_decoder.py` and
+   `tests/codec/der/test_decoder.py`.** CER and DER inherit the limit through
+   module import rather than reimplementing it, but the mirrors are what stop
+   a future refactor from silently exempting one codec.
+
+Steps 1-3 belong in one `TestCase` class named after the limit, for example
+`NestingDepthLimitTestCase` or `LengthFieldLimitTestCase`.
+
+## Special patterns
+
+**Monkeypatching interpreter globals.** `decoder.sys` *is* the real `sys`
+module, so the platform-limit tests mutate it globally to exercise a branch
+unreachable on a 64-bit machine. The `finally` restore is mandatory and the
+pattern is not safe under parallel test execution
+(`LengthFieldLimitTestCase.testLengthValueAbovePlatformLimitIsRejected` in
+`tests/codec/ber/test_decoder.py`):
+
+```python
+originalMaxsize = decoder.sys.maxsize
+decoder.sys.maxsize = 0x7fffffff
+try:
+    ...
+finally:
+    decoder.sys.maxsize = originalMaxsize
+```
+
+**Cross-codec behavioral regressions.** When a bug affects every codec, test
+it once against all of them rather than copying a case into four files.
+`tests/codec/test_encoder_no_mutation.py` is the model: it declares a `codecs`
+tuple of five entry points (`ber` in both definite and indefinite mode, `cer`,
+`der`, `native`) atop `DefaultedComponentsNoMutationTestCase`, then drives
+every case through `itertools.product`. Its `_snapshot` helper captures
+component state using `getComponentByName(name, instantiate=False)`. The
+`instantiate=False` is essential, because the default would itself materialize
+the absent component the test is trying to prove untouched.
+
+**`self.subTest`** appears only in that newest module. It is fine to use in
+new cross-product tests and unnecessary elsewhere.
+
+## Layout
+
+`tests/` mirrors the package:
+
+```
+tests/
+├── base.py                        BaseTestCase
+├── __main__.py                    aggregate suite
+├── test_debug.py
+├── type/                          test_univ, test_char, test_tag, test_constraint,
+│                                  test_namedtype, test_namedval, test_opentype, test_useful
+└── codec/
+    ├── test_streaming.py          stream wrappers
+    ├── test_encoder_no_mutation.py  cross-codec regression
+    ├── ber/  cer/  der/  native/  test_encoder.py + test_decoder.py each
+```
+
+Every directory carries both `__init__.py` and `__main__.py`. Cross-codec
+tests live at the `tests/codec/` level rather than inside one codec's
+directory. `tests/compat/` was removed in commit `0cf7578` when the compat
+shims went away; a stale `__pycache__` may still exist on disk and can be
+ignored.


### PR DESCRIPTION
Make AGENTS.md the canonical, tool-neutral agent context (CLAUDE.md becomes a symlink to it) and index two deep-dive documents kept at the docs/ root, outside the Sphinx tree and the sdist: docs/ARCHITECTURE.md (subsystem internals, security hardening inventory, compatibility surface, known warts) and docs/TESTING.md (suite conventions and the security-test template). Documentation references cite symbols rather than line numbers so they survive unrelated edits.

Add four task skills under .agents/skills/ -- issue-pr-triage, security-fix, pre-commit-check, add-test -- with .claude/skills symlinked to them, and extend .gitignore to cover macOS droppings, virtualenv directories, scratch patches, lock files and machine-local agent settings.

Expand SECURITY.md with the project's vulnerability scope: what qualifies for a private advisory and a CVE versus what is handled as an ordinary public bug report. Follow-up to #96, which asked where to report a vulnerability and prompted the original SECURITY.md; that document said how to report but never what qualifies.