### PR TITLE
Reject empty fragments in constructed BIT STRING decoding (#119)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ Revision 0.7.0, released XX-XX-2026
   qualifies for a private advisory and a CVE versus what is handled
   as an ordinary public bug report
   [issue #96](https://github.com/pyasn1/pyasn1/issues/96)
+- Fixed IndexError leaking from the BER decoder when a constructed BIT
+  STRING contains a zero-length fragment, which lacks the mandatory
+  initial "unused bits" octet. Such fragments are now rejected with
+  PyAsn1Error in both the definite and indefinite length forms
+  [issue #119](https://github.com/pyasn1/pyasn1/issues/119)
 
 Revision 0.6.4, released 08-07-2026
 ---------------------------------------

--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -241,6 +241,11 @@ class BitStringPayloadDecoder(AbstractSimplePayloadDecoder):
                 if isinstance(component, SubstrateUnderrunError):
                     yield component
 
+            if not component:
+                raise error.PyAsn1Error(
+                    'Missing initial octet in a constructed BIT STRING fragment'
+                )
+
             trailingBits = component[0]
             if trailingBits > 7:
                 raise error.PyAsn1Error(
@@ -286,6 +291,11 @@ class BitStringPayloadDecoder(AbstractSimplePayloadDecoder):
 
             if component is eoo.endOfOctets:
                 break
+
+            if not component:
+                raise error.PyAsn1Error(
+                    'Missing initial octet in a constructed BIT STRING fragment'
+                )
 
             trailingBits = component[0]
             if trailingBits > 7:

--- a/tests/codec/ber/test_decoder.py
+++ b/tests/codec/ber/test_decoder.py
@@ -200,6 +200,34 @@ class BitStringDecoderTestCase(BaseTestCase):
         else:
             assert 0, 'accepted mis-encoded bit-string constructed out of an integer'
 
+    def testEmptyFragmentDefMode(self):
+        # A constructed BIT STRING whose fragment carries no octets at all
+        # lacks the mandatory initial "unused bits" octet (X.690 8.6.2.3).
+        try:
+            decoder.decode(bytes((35, 2, 3, 0)))
+        except error.PyAsn1Error:
+            pass
+        else:
+            assert 0, 'accepted constructed BIT STRING with an empty fragment'
+
+    def testEmptyFragmentIndefMode(self):
+        try:
+            decoder.decode(bytes((35, 128, 3, 0, 0, 0)))
+        except error.PyAsn1Error:
+            pass
+        else:
+            assert 0, 'accepted constructed BIT STRING with an empty fragment'
+
+    def testEmptyFragmentIndefModePrimitiveTag(self):
+        # Reported in https://github.com/pyasn1/pyasn1/issues/119 -- used to
+        # raise IndexError instead of a descriptive PyAsn1Error.
+        try:
+            decoder.decode(bytes((3, 128, 96, 0, 0, 0)))
+        except error.PyAsn1Error:
+            pass
+        else:
+            assert 0, 'accepted indefinite-length BIT STRING with an empty fragment'
+
 
 class OctetStringDecoderTestCase(BaseTestCase):
     def testDefMode(self):


### PR DESCRIPTION
## Problem

Decoding a constructed BIT STRING whose reassembly encounters a zero-length
fragment raises a bare `IndexError` instead of a `PyAsn1Error`:

```python
from pyasn1.codec.ber import decoder
decoder.decode(b'\x03\x80\x60\x00\x00')
```

```
  File ".../pyasn1/codec/ber/decoder.py", line 290, in indefLenValueDecoder
    trailingBits = component[0]
IndexError: index out of range
```

(reported in #119)

## Cause

A constructed BIT STRING is reassembled from inner fragments, and each
fragment must carry at least the leading "unused bits" octet (X.690 8.6.2.3).
Both reassembly loops in `BitStringPayloadDecoder` read `component[0]`
unconditionally, so a fragment that decodes to zero octets throws `IndexError`
out of the codec instead of a descriptive `PyAsn1Error`.

The same defect is present in the definite-length constructed path a few lines
above the one in the traceback, e.g. `decoder.decode(b'\x23\x02\x03\x00')`.

## Fix

Guard both paths and reject a zero-length fragment with `PyAsn1Error` before
indexing it. The `BitStringPayloadDecoder` is subclassed (not overridden on
this point) by the CER and DER decoders, so the check applies to all three.

## Tests

Added `testEmptyFragmentDefMode`, `testEmptyFragmentIndefMode`, and
`testEmptyFragmentIndefModePrimitiveTag` (the exact case from #119) to
`BitStringDecoderTestCase`. Each fails with `IndexError` before the change and
passes after.

`python -Werror -m unittest discover -s tests` — 1264 tests, all passing.